### PR TITLE
Don't crash the app if the hardcoded json schedules list is empty

### DIFF
--- a/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
+++ b/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
@@ -1297,19 +1297,6 @@ static NSString * const kQueueName = @"APCScheduler CoreData query queue";
             else
             {
                 schedulesArray = maybeSchedulesArray;
-
-                if (schedulesArray.count == 0)
-                {
-                    // This may not be an error, but it probably is.
-                    errorToReport = [NSError errorWithCode: APCErrorJSONTasksAndSchedulesIsEmptyCode
-                                                    domain: APCErrorDomainLoadingTasksAndSchedules
-                                             failureReason: APCErrorJSONTasksAndSchedulesIsEmptyReason
-                                        recoverySuggestion: APCErrorJSONTasksAndSchedulesIsEmptySuggestion];
-                }
-                else
-                {
-                    // Whew.  Looks like we got real data.  Ready to process.
-                }
             }
         }
 


### PR DESCRIPTION
Removes code that creates an incorrect error that then explodes the app.
