### PR TITLE
Bridge-719

### DIFF
--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.h
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.h
@@ -58,5 +58,6 @@ typedef NS_ENUM(NSUInteger, APCPermissionStatus) {
 - (void)requestForPermissionForType:(APCSignUpPermissionsType)type withCompletion:(APCPermissionsBlock)completion;
 
 - (NSString *)permissionDescriptionForType:(APCSignUpPermissionsType)type;
+- (NSError *)permissionDeniedErrorForType:(APCSignUpPermissionsType)type;
 
 @end

--- a/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
+++ b/APCAppCore/APCAppCore/Library/Permissions/APCPermissionsManager.m
@@ -114,6 +114,9 @@ typedef NS_ENUM(NSUInteger, APCPermissionsErrorCode) {
     BOOL isGranted = NO;
     [[NSUserDefaults standardUserDefaults]synchronize];
     switch (type) {
+        case kAPCSignUpPermissionsTypeNone:
+            isGranted = YES;
+            break;
         case kAPCSignUpPermissionsTypeHealthKit:
         {
             HKCharacteristicType *dateOfBirth = [HKCharacteristicType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierDateOfBirth];

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.h
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.h
@@ -36,6 +36,7 @@
 #import "APCScheduledTask.h"
 #import "APCTaskGroup.h"
 #import "ORKFileResult+Filename.h"
+#import "APCConstants.h"
 
 @class APCAppDelegate;
 @class APCDataArchive;
@@ -77,6 +78,7 @@
  */
 - (void)addSpatialSpanMemoryResultsToArchive:(ORKSpatialSpanMemoryResult *) __unused result;
 - (void)addTappingResultsToArchive:(ORKTappingIntervalResult *)__unused result;
+- (APCSignUpPermissionsType)requiredPermission;
 
 - (void) archiveResults;
 

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
@@ -424,6 +424,11 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
     
 }
 
+- (APCSignUpPermissionsType)requiredPermission
+{
+    return kAPCSignUpPermissionsTypeNone;
+}
+
 #pragma mark - Upload
 
 - (void)uploadResultSummary: (NSString *)resultSummary


### PR DESCRIPTION
Add Permission check capability to activities
Can be overridden by any extension of APCBaseTaskViewController
Shows the same text as a failure during the signup process
Adds default of none and also handles none case in isPermissionsGrantedForType

Tested toggling to insure it refreshes permissions, getting error and then going to settings to toggle or vice versa and coming back results in correct behavior.

Will create open PD/BCS PRs once we have a commit to target in AppCore.
