### PR TITLE
Get CoreMotion status before trying to use it

### DIFF
--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
@@ -101,6 +101,11 @@ static CGFloat const kTableViewSectionHeaderHeight = 77;
     self.dateFormatter = [NSDateFormatter new];
     [self configureRefreshControl];
     self.lastKnownSystemDate = nil;
+    
+    self.permissionManager = [[APCPermissionsManager alloc] init];
+
+    // make sure we know the state of CoreMotion permissions so it's available when we need it
+    [self.permissionManager requestForPermissionForType:kAPCSignUpPermissionsTypeCoremotion withCompletion:nil];
 }
 
 - (void) viewWillAppear: (BOOL) animated
@@ -114,8 +119,6 @@ static CGFloat const kTableViewSectionHeaderHeight = 77;
     [self reloadTasksFromCoreData];
     [self checkForAndMaybeRespondToSystemDateChange];
     
-    self.permissionManager = [[APCPermissionsManager alloc] init];
-
     APCLogViewControllerAppeared();
 }
 


### PR DESCRIPTION
also APCPermissionsManager requestForPermissionForType:withCompletion: was pretty badly broken--utterly non-reentrant, and just about guaranteed to behave unpredictably if called immediately after creating the first PermissionsManager instance, because LocationManager delegate callbacks would call (and then delete) completion handlers intended for other requests. So I fixed that while I was at it.
