### PR TITLE
Feature/bridge 663 & 806

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -736,6 +736,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		045D0CBD1BBAFDC500330C7E /* APCModel 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "APCModel 8.xcdatamodel"; sourceTree = "<group>"; };
 		0494397F1B8FC04000CAE23C /* APCDownloadDataViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCDownloadDataViewController.h; sourceTree = "<group>"; };
 		049439801B8FC04000CAE23C /* APCDownloadDataViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCDownloadDataViewController.m; sourceTree = "<group>"; };
 		04FB64451BB4883900D0A50D /* APCTaskImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCTaskImporter.h; sourceTree = "<group>"; };
@@ -4164,6 +4165,7 @@
 		F5F128981A2F78490015982C /* APCModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				045D0CBD1BBAFDC500330C7E /* APCModel 8.xcdatamodel */,
 				04FB64491BB4A11A00D0A50D /* APCModel 7.xcdatamodel */,
 				366345791B1F84F0003CC0EF /* APCModel 6.xcdatamodel */,
 				366345781B1F84DD003CC0EF /* APCModel 5.xcdatamodel */,
@@ -4172,7 +4174,7 @@
 				36469C321AA1650F00C10CA7 /* APCModel 3.xcdatamodel */,
 				F5F128991A2F78490015982C /* APCModel.xcdatamodel */,
 			);
-			currentVersion = 04FB64491BB4A11A00D0A50D /* APCModel 7.xcdatamodel */;
+			currentVersion = 045D0CBD1BBAFDC500330C7E /* APCModel 8.xcdatamodel */;
 			path = APCModel.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/.xccurrentversion
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>APCModel 7.xcdatamodel</string>
+	<string>APCModel 8.xcdatamodel</string>
 </dict>
 </plist>

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/APCModel 8.xcdatamodel/contents
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/APCModel 8.xcdatamodel/contents
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7701" systemVersion="14D136" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="APCDBStatus" representedClassName="APCDBStatus" syncable="YES">
+        <attribute name="status" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerDailyDosageRecord" representedClassName="APCMedTrackerDailyDosageRecord" syncable="YES">
+        <attribute name="dateThisRecordRepresents" attributeType="Date" indexed="YES" syncable="YES"/>
+        <attribute name="numberOfDosesTakenForThisDate" attributeType="Integer 16" minValueString="0" defaultValueString="0" syncable="YES"/>
+        <relationship name="prescriptionIAmBasedOn" maxCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescription" inverseName="actualDosesTaken" inverseEntity="APCMedTrackerPrescription" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerInflatableItem" representedClassName="APCMedTrackerInflatableItem" syncable="YES">
+        <attribute name="name" attributeType="String" minValueString="1" indexed="YES" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerMedication" representedClassName="APCMedTrackerMedication" parentEntity="APCMedTrackerInflatableItem" syncable="YES">
+        <relationship name="prescriptionsWhereIAmUsed" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescription" inverseName="medication" inverseEntity="APCMedTrackerPrescription" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerPossibleDosage" representedClassName="APCMedTrackerPossibleDosage" parentEntity="APCMedTrackerInflatableItem" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="Float" minValueString="0" syncable="YES"/>
+        <relationship name="prescriptionsWhereIAmUsed" optional="YES" toMany="YES" minCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescription" inverseName="dosage" inverseEntity="APCMedTrackerPrescription" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerPrescription" representedClassName="APCMedTrackerPrescription" syncable="YES">
+        <attribute name="dateStartedUsing" attributeType="Date" syncable="YES"/>
+        <attribute name="dateStoppedUsing" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="didStopUsingOnDoctorsOrders" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="numberOfTimesPerDay" attributeType="Integer 16" minValueString="0" defaultValueString="0" syncable="YES"/>
+        <attribute name="zeroBasedDaysOfTheWeek" attributeType="String" syncable="YES"/>
+        <relationship name="actualDosesTaken" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCMedTrackerDailyDosageRecord" inverseName="prescriptionIAmBasedOn" inverseEntity="APCMedTrackerDailyDosageRecord" syncable="YES"/>
+        <relationship name="color" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescriptionColor" inverseName="prescriptionsWhereIAmUsed" inverseEntity="APCMedTrackerPrescriptionColor" syncable="YES"/>
+        <relationship name="dosage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerPossibleDosage" inverseName="prescriptionsWhereIAmUsed" inverseEntity="APCMedTrackerPossibleDosage" syncable="YES"/>
+        <relationship name="medication" maxCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerMedication" inverseName="prescriptionsWhereIAmUsed" inverseEntity="APCMedTrackerMedication" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerPrescriptionColor" representedClassName="APCMedTrackerPrescriptionColor" parentEntity="APCMedTrackerInflatableItem" syncable="YES">
+        <attribute name="alphaAsFloat" attributeType="Float" minValueString="0" maxValueString="1" defaultValueString="1" syncable="YES"/>
+        <attribute name="blueAsInteger" attributeType="Integer 16" minValueString="0" maxValueString="255" defaultValueString="50" syncable="YES"/>
+        <attribute name="greenAsInteger" optional="YES" attributeType="Integer 16" minValueString="0" maxValueString="255" defaultValueString="50" syncable="YES"/>
+        <attribute name="naturalSortOrder" optional="YES" attributeType="Integer 16" minValueString="0" defaultValueString="0" indexed="YES" syncable="YES"/>
+        <attribute name="redAsInteger" optional="YES" attributeType="Integer 16" minValueString="0" maxValueString="255" defaultValueString="50" syncable="YES"/>
+        <relationship name="prescriptionsWhereIAmUsed" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescription" inverseName="color" inverseEntity="APCMedTrackerPrescription" syncable="YES"/>
+    </entity>
+    <entity name="APCResult" representedClassName="APCResult" syncable="YES">
+        <attribute name="archiveFilename" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="metaData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="resultSummary" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskRunID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="uploaded" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <relationship name="task" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APCTask" inverseName="results" inverseEntity="APCTask" syncable="YES"/>
+    </entity>
+    <entity name="APCStoredUserData" representedClassName="APCStoredUserData" syncable="YES">
+        <attribute name="allowContact" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="biologicalSex" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="birthDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="bloodType" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="consentSignatureDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="consentSignatureImage" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="consentSignatureName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="customSurveyQuestion" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dailyScalesCompletionCounter" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="ethnicity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="glucoseLevels" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasHeartDisease" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="homeLocationAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="homeLocationLat" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="homeLocationLong" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="medicalConditions" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="medications" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="profileImage" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="secondaryInfoSaved" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="serverConsented" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="sharedOptionSelection" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="sleepTime" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskCompletion" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="userConsented" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="wakeUpTime" optional="YES" attributeType="Date" syncable="YES"/>
+    </entity>
+    <entity name="APCTask" representedClassName="APCTask" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="sortString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskClassName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskCompletionTimeString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskContentFileName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskDescription" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="taskExpires" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskFinished" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskGuid" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskHRef" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskID" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="taskIsOptional" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="taskScheduledFor" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskStarted" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskVersionNumber" optional="YES" attributeType="Integer 32" defaultValueString="0" indexed="YES" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <relationship name="results" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCResult" inverseName="task" inverseEntity="APCResult" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="APCDBStatus" positionX="-1341" positionY="72" width="171" height="58"/>
+        <element name="APCMedTrackerDailyDosageRecord" positionX="-1188" positionY="621" width="216" height="88"/>
+        <element name="APCMedTrackerInflatableItem" positionX="-965" positionY="1080" width="299" height="58"/>
+        <element name="APCMedTrackerMedication" positionX="-1260" positionY="935" width="180" height="58"/>
+        <element name="APCMedTrackerPossibleDosage" positionX="-1269" positionY="758" width="216" height="73"/>
+        <element name="APCMedTrackerPrescription" positionX="-938" positionY="764" width="218" height="178"/>
+        <element name="APCMedTrackerPrescriptionColor" positionX="-666" positionY="729" width="207" height="133"/>
+        <element name="APCResult" positionX="-1359" positionY="297" width="171" height="210"/>
+        <element name="APCStoredUserData" positionX="-1593" positionY="72" width="200" height="435"/>
+        <element name="APCTask" positionX="-873" positionY="71" width="207" height="315"/>
+    </elements>
+</model>

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/APCModel 8.xcdatamodel/contents
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/APCModel 8.xcdatamodel/contents
@@ -94,7 +94,9 @@
         <attribute name="taskScheduledFor" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="taskStarted" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="taskTitle" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="taskVersionNumber" optional="YES" attributeType="Integer 32" defaultValueString="0" indexed="YES" syncable="YES"/>
+        <attribute name="taskType" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="taskVersionDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskVersionName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <relationship name="results" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCResult" inverseName="task" inverseEntity="APCResult" syncable="YES"/>
     </entity>
@@ -108,6 +110,6 @@
         <element name="APCMedTrackerPrescriptionColor" positionX="-666" positionY="729" width="207" height="133"/>
         <element name="APCResult" positionX="-1359" positionY="297" width="171" height="210"/>
         <element name="APCStoredUserData" positionX="-1593" positionY="72" width="200" height="435"/>
-        <element name="APCTask" positionX="-873" positionY="71" width="207" height="315"/>
+        <element name="APCTask" positionX="-873" positionY="71" width="207" height="345"/>
     </elements>
 </model>

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask+Bridge.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask+Bridge.m
@@ -113,6 +113,8 @@
                 SBBSurvey * sbbSurvey = (SBBSurvey*) survey;
                 [self.managedObjectContext performBlockAndWait:^{
                     self.taskTitle = sbbSurvey.name;
+                    self.taskVersionName = sbbSurvey.guid;
+                    self.taskVersionDate = sbbSurvey.createdOn;
                     self.rkTask = [APCTask rkTaskFromSBBSurvey:survey];
                     NSError * saveError;
                     [self saveToPersistentStore:&saveError];

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask.h
@@ -53,7 +53,9 @@
 @property (nonatomic, retain) NSDate * taskScheduledFor;
 @property (nonatomic, retain) NSDate * taskStarted;
 @property (nonatomic, retain) NSString * taskTitle;
-@property (nonatomic, retain) NSNumber * taskVersionNumber;
+@property (nonatomic, retain) NSNumber * taskType;
+@property (nonatomic, retain) NSDate * taskVersionDate;
+@property (nonatomic, retain) NSString * taskVersionName;
 @property (nonatomic, retain) NSDate * updatedAt;
 @property (nonatomic, retain) NSSet *results;
 @end

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask.m
@@ -52,7 +52,9 @@
 @dynamic taskScheduledFor;
 @dynamic taskStarted;
 @dynamic taskTitle;
-@dynamic taskVersionNumber;
+@dynamic taskType;
+@dynamic taskVersionDate;
+@dynamic taskVersionName;
 @dynamic updatedAt;
 @dynamic results;
 

--- a/APCAppCore/APCAppCore/Library/Categories/NSDateComponents+Helper.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDateComponents+Helper.h
@@ -67,6 +67,11 @@
 - (NSInteger) cronDayOfWeekForDay: (NSInteger) dayInCurrentMonthYearAndCalendar;
 - (NSNumber *) cronDayOfWeekAsNSNumberForDay: (NSNumber *) dayInCurrentMonthYearAndCalendar;
 
+/**
+ Convert to a Joda time readable time string
+ */
+- (NSString *) toJodaReadableTimeString;
+
 
 /**
  Returns the integer last day of the month.  For example,

--- a/APCAppCore/APCAppCore/Library/Categories/NSDateComponents+Helper.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDateComponents+Helper.m
@@ -177,6 +177,16 @@ static NSTimeZone *_localTimeZone = nil;
 				   fromDate: date];
 }
 
+- (NSString *) toJodaReadableTimeString
+{
+    NSDate *dateForTime = [[NSDateComponents gregorianCalendar] dateFromComponents:self];
+    
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setDateFormat:@"HH:mm:ss"];
+    
+    return [formatter stringFromDate:dateForTime];
+}
+
 
 /**
  Again -- we're modifying this DateComponents object, by design.

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.h
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.h
@@ -46,6 +46,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "APCTask.h"
 
 @class ORKTaskResult;
 
@@ -61,6 +62,16 @@
  @return    APCDataArchive      An instance of APCDataArchive
  */
 - (id)initWithReference: (NSString *)reference;
+
+/**
+ Designated Initializer
+ 
+ @param     reference           Reference for the archive used as a directory name in temp directory
+ @param     task                APCTask associated with this Data
+ 
+ @return    APCDataArchive      An instance of APCDataArchive
+ */
+- (id)initWithReference: (NSString *)reference task:(APCTask *)task;
 
 /**
  Inserts json data into the archive.

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.m
@@ -40,12 +40,15 @@
 #import "NSDate+Helper.h"
 #import "APCJSONSerializer.h"
 #import "NSError+APCAdditions.h"
+#import "APCConstants.h"
 
 static NSString * kFileInfoNameKey                  = @"filename";
 static NSString * kUnencryptedArchiveFilename       = @"unencrypted.zip";
 static NSString * kFileInfoTimeStampKey             = @"timestamp";
 static NSString * kFileInfoContentTypeKey           = @"contentType";
 static NSString * kTaskRunKey                       = @"taskRun";
+static NSString * kSurveyCreatedOnKey               = @"surveyCreatedOn";
+static NSString * kSurveyGuidKey                    = @"surveyGuid";
 static NSString * kFilesKey                         = @"files";
 static NSString * kAppNameKey                       = @"appName";
 static NSString * kAppVersionKey                    = @"appVersion";
@@ -194,6 +197,10 @@ static NSString * kJsonInfoFilename                 = @"info.json";
         [self.infoDict setObject:[APCUtilities phoneInfo] forKey:kPhoneInfoKey];
         [self.infoDict setObject:[NSUUID new].UUIDString forKey:kTaskRunKey];
         [self.infoDict setObject:self.reference forKey:kItemKey];
+        if ([self.task.taskType isEqualToNumber:@(APCTaskTypeSurveyTask)]) {
+            [self.infoDict setObject:self.task.taskVersionName forKey:kSurveyGuidKey];
+            [self.infoDict setObject:self.task.taskVersionDate forKey:kSurveyCreatedOnKey];
+        }
         
         [self insertIntoArchive:self.infoDict filename:kJsonInfoFilename];
         

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.m
@@ -57,6 +57,7 @@ static NSString * kJsonInfoFilename                 = @"info.json";
 @interface APCDataArchive ()
 
 @property (nonatomic, strong) NSString *reference;
+@property (nonatomic, strong) APCTask *task;
 @property (nonatomic, strong) ZZArchive *zipArchive;
 @property (nonatomic, strong) NSMutableArray *zipEntries;
 @property (nonatomic, strong) NSMutableArray *filesList;
@@ -72,6 +73,19 @@ static NSString * kJsonInfoFilename                 = @"info.json";
     self = [super init];
     if (self) {
         _reference = reference;
+        [self createArchive];
+    }
+    
+    return self;
+}
+
+// designated initializer
+- (id)initWithReference: (NSString *)reference task:(APCTask *)task
+{
+    self = [super init];
+    if (self) {
+        _reference = reference;
+        _task = task;
         [self createArchive];
     }
     

--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
@@ -86,6 +86,29 @@ typedef enum : NSUInteger {
     APCTaskSourceMedicationTracker  = 1 << 3,   // 0000 0000 0000 1000
 }   APCTaskSource;
 
+/**
+ Indicates the type of task to be done. A Survey is typically a
+ question and answer format while activities will involve doing
+ somethiing like tapping or speaking into the phone
+ 
+ Please feel free to add your own sources, here.  If you
+ do, please respect the following:
+ 
+ -  Make them bitmask-friendly, using the examples below.
+ 
+ -  Do NOT change the values of the existing items. Those
+ are values in our users' current databases.
+ 
+ -  Add your enum name to the switch() statement in the
+ function NSStringFromAPCTaskType(), inside
+ APCConstants.m.
+ */
+typedef enum : NSInteger {
+    APCTaskTypeSurveyTask                   = 0,
+    APCTaskTypeActivityTask                 = 1 << 0,   // 0000 0000 0000 0001
+    APCTaskTypeSurveyAndActivityTask        = 1 << 1,   // 0000 0000 0000 0010
+}   APCTaskType;
+
 // ---------------------------------------------------------
 #pragma mark - Enum Translation Functions
 // ---------------------------------------------------------
@@ -100,6 +123,16 @@ NSString *NSStringFromAPCTaskSource              (APCTaskSource taskSource);
 NSString *NSStringFromAPCTaskSourceAsNumber      (NSNumber *taskSourceAsNumber);
 NSString *NSStringShortFromAPCTaskSource         (APCTaskSource taskSource);
 NSString *NSStringShortFromAPCTaskSourceAsNumber (NSNumber *taskSourceAsNumber);
+
+/*
+ Converts an APCTaskSource object or value to a string.
+ 
+ @see APCTaskType
+ */
+NSString *NSStringFromAPCTaskType               (APCTaskType taskType);
+NSString *NSStringFromAPCTaskTypeAsNumber       (NSNumber *taskTypeAsNumber);
+NSString *NSStringShortFromAPCTaskType          (APCTaskType taskType);
+NSString *NSStringShortFromAPCTaskTypeAsNumber  (NSNumber *taskTypeAsNumber);
 
 
 // ---------------------------------------------------------

--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
@@ -39,6 +39,9 @@
 #pragma mark - Enum Translation Functions
 // ---------------------------------------------------------
 
+/**
+ APCTaskSource Methods
+ */
 NSString *NSStringFromAPCTaskSource (APCTaskSource taskSource)
 {
     NSString *result = nil;
@@ -74,6 +77,41 @@ NSString *NSStringShortFromAPCTaskSourceAsNumber (NSNumber *taskSourceAsNumber)
     return NSStringShortFromAPCTaskSource (taskSourceAsNumber.integerValue);
 }
 
+/**
+ APCTaskType Methods
+ */
+NSString *NSStringFromAPCTaskType (APCTaskType taskType)
+{
+    NSString *result = nil;
+    
+    switch (taskType)
+    {
+        case APCTaskTypeSurveyTask:                 result = @"APCTaskTypeSurveyTask";              break;
+        case APCTaskTypeActivityTask:               result = @"APCTaskTypeActivityTask";            break;
+        case APCTaskTypeSurveyAndActivityTask:      result = @"APCTaskTypeSurveyAndActivityTask";   break;
+            
+        default: result = @"Unknown"; break;
+    }
+    
+    return result;
+}
+
+NSString *NSStringFromAPCTaskTypeAsNumber (NSNumber *taskTypeAsNumber)
+{
+    return NSStringFromAPCTaskType (taskTypeAsNumber.integerValue);
+}
+
+NSString *NSStringShortFromAPCTaskType (APCTaskType taskType)
+{
+    NSString *result = NSStringFromAPCTaskType (taskType);
+    result = [result substringFromIndex: @"APCTaskType".length];
+    return result;
+}
+
+NSString *NSStringShortFromAPCTaskTypeAsNumber (NSNumber *taskTypeAsNumber)
+{
+    return NSStringShortFromAPCTaskType (taskTypeAsNumber.integerValue);
+}
 
 
 // ---------------------------------------------------------

--- a/APCAppCore/APCAppCore/Library/Objects/APCJSONSerializer.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCJSONSerializer.m
@@ -35,6 +35,7 @@
 #import "ORKAnswerFormat+Helper.h"
 #import "NSDate+Helper.h"
 #import <CoreData/CoreData.h>
+#import "NSDateComponents+helper.h"
 
 
 
@@ -253,6 +254,17 @@ static NSString * const kRegularExpressionPatternMatchingUUIDs = (@"[a-fA-F0-9]{
         NSDate *theDate = (NSDate *) sourceObject;
         NSString *sageFriendlyDate = theDate.toStringInISO8601Format;
         result = sageFriendlyDate;
+    }
+    
+    /*
+     RK returns a DateComponents object when a specific time is selected. We
+     need to convert that to a Joda parseable time like hh:mm:ss for Bridge.
+     */
+    else if ([sourceObject isKindOfClass: [NSDateComponents class]])
+    {
+        NSDateComponents *theDateComponents = (NSDateComponents *) sourceObject;
+        NSString *timeString = [theDateComponents toJodaReadableTimeString];
+        result = timeString;
     }
 
     /*

--- a/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
+++ b/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
@@ -446,7 +446,7 @@ static NSString * const kQueueName = @"APCScheduler CoreData query queue";
         }
         
         /*
-         Loop through the incoming items and save/udpate everything.
+         Loop through the incoming items and save/update everything.
          */
         [self processTasks: jsonCopyOfSageTasks
                 fromSource: APCTaskSourceServer

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
@@ -378,7 +378,6 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
                 [self addSpatialSpanMemoryResultsToArchive:spatialSpanMemoryResult];
             }
             
-            
             else if ([result isKindOfClass:[ORKQuestionResult class]])
             {
                 [self addResultToArchive:result];

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
@@ -335,7 +335,7 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
 - (void) archiveResults
 {
     //get a fresh archive
-    self.archive = [[APCDataArchive alloc]initWithReference:self.task.identifier];
+    self.archive = [[APCDataArchive alloc]initWithReference:self.task.identifier task:self.scheduledTask];
     
     __weak typeof(self) weakSelf = self;
     //add dictionaries or json data to the archive, calling completeArchive when done


### PR DESCRIPTION
Update APCTask to hold versionName, versionDate, and taskType
Store survey guid and createdOn in APCTask.versionName/versionDate when survey is retrieved
Add taskType to Task Import
Include survey guid and created on info when creating info.json for a survey result
Remove taskVersionNumber since it is no longer used (we use the task.guid field to compare tasks now)
