### PR TITLE
Updates to be compatible with RK 1.2

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCSmartSurveyTask.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCSmartSurveyTask.m
@@ -568,7 +568,7 @@ static APCDummyObject * _dummyObject;
     NSMutableArray * options = [NSMutableArray array];
     [localConstraints.enumeration enumerateObjectsUsingBlock:^(SBBSurveyQuestionOption* option, NSUInteger __unused idx, BOOL * __unused stop) {
         NSString * detailText = option.detail.length > 0 ? option.detail : nil;
-        ORKTextChoice * choice = [ORKTextChoice choiceWithText:option.label detailText:detailText value:option.value];
+        ORKTextChoice * choice = [ORKTextChoice choiceWithText:option.label detailText:detailText value:option.value exclusive:!localConstraints.allowMultipleValue];
         [options addObject: choice];
     }];
     if (localConstraints.allowOtherValue) {

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
@@ -339,7 +339,7 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
     
     __weak typeof(self) weakSelf = self;
     //add dictionaries or json data to the archive, calling completeArchive when done
-    [self.result.results enumerateObjectsUsingBlock:^(ORKStepResult *stepResult, NSUInteger __unused idx, BOOL * __unused stop) {
+    for (ORKStepResult *stepResult in self.result.results) {
         [stepResult.results enumerateObjectsUsingBlock:^(ORKResult *result, NSUInteger __unused idx, BOOL *__unused stop) {
             __strong typeof(self) strongSelf = weakSelf;
             //Update date if needed
@@ -387,7 +387,7 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
                 APCLogError(@"Result not processed for : %@", result.identifier);
             }
         }];
-    }];
+    }
 }
 
 /**
@@ -504,7 +504,7 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
     APCTask * scheduledTask = (APCTask*)[appDelegate.dataSubstrate.mainContext objectWithID:objID];
     id localRestorationData = [coder decodeObjectForKey:@"restorationData"];
     if (scheduledTask) {
-        APCBaseTaskViewController * tvc =[[self alloc] initWithTask:task restorationData:localRestorationData];
+        APCBaseTaskViewController * tvc =[[self alloc] initWithTask:task restorationData:localRestorationData delegate:self];
         tvc.scheduledTask = scheduledTask;
         tvc.restorationIdentifier = [task identifier];
         tvc.restorationClass = self;


### PR DESCRIPTION
exclusive allows single choice answers even for multiple answer questions, like None of the Above. Until that capability is in SBBSurveyQuestionOption, default to acting the same as the entire answer.

The enumeration gets more picky, requiring an object and then a casting. I liked the solution followed by other RK projects of making the first one a simple for each loop and made the same change here.

Delegate now required, supplying self.
