### PR TITLE
Only find UITabBarController for newsfeed if its actually needed

### DIFF
--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -697,10 +697,10 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
         
         BOOL newsFeedTab = [self.initializationOptions[kNewsFeedTabKey] boolValue];
         
-        NSArray *items = tabBarController.tabBar.items;
-        UITabBarItem *item = items[kAPCNewsFeedTabIndex];
-        
         if (newsFeedTab){
+            NSArray *items = tabBarController.tabBar.items;
+            UITabBarItem *item = items[kAPCNewsFeedTabIndex];
+            
             NSUInteger unreadPostsCount = [self.dataSubstrate.newsFeedManager unreadPostsCount];
             NSNumber *unreadValue = @(unreadPostsCount);
             


### PR DESCRIPTION
If newsFeedTab is false, we don't need to look for/attempt to populate the news feed tab bar item.
