### PR TITLE
Comment out verification_server check

### DIFF
--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchiverAndUploader.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchiverAndUploader.m
@@ -1809,11 +1809,11 @@ static NSString *folderPathForUploadOperations = nil;
      to Bad Guys in production.  Even if the code isn't called,
      if it's in RAM at all, it can be exploited.
      */
-    #ifdef USE_DATA_VERIFICATION_SERVER
-
-        [APCDataVerificationClient uploadDataFromFileAtPath: self.unencryptedZipPath];
-        
-    #endif
+//    #ifdef USE_DATA_VERIFICATION_SERVER
+//
+//        [APCDataVerificationClient uploadDataFromFileAtPath: self.unencryptedZipPath];
+//        
+//    #endif
 
 
 


### PR DESCRIPTION
Comment out rather than removing, but this code can lead to misleading issues now with the new transport security stuff in iOS 9.

Removing it completely would also be fine, but thought it made sense to leave this in to help understand what the APCDataVerificationClient did. Alternatively we can just rip that out completely.
