### PR TITLE
turn off data verification service when in debug

### DIFF
--- a/APCAppCore/APCAppCore/Library/DataVerificationClient/APCDataVerificationServerAccessControl.h
+++ b/APCAppCore/APCAppCore/Library/DataVerificationClient/APCDataVerificationServerAccessControl.h
@@ -43,10 +43,10 @@
  helpful during debugging.)
  */
 
-#if DEBUG
-
-   #define USE_DATA_VERIFICATION_SERVER
-
-#endif
+//#if DEBUG
+//
+//   #define USE_DATA_VERIFICATION_SERVER
+//
+//#endif
 
 


### PR DESCRIPTION
This resolves some issues with transport security as well as error messages/other misleading messages when the server is not available.
