### PR TITLE
Bridge-789

### DIFF
--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
@@ -336,6 +336,9 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
 {
     //get a fresh archive
     self.archive = [[APCDataArchive alloc]initWithReference:self.task.identifier task:self.scheduledTask];
+    // Track filenames. Occasionally RK spit out 2 files with the same name which causes trouble on the backend
+    // if the archive has 2 files named the same. See BRIDGE-789.
+    NSMutableSet *filenames = [NSMutableSet new];
     
     __weak typeof(self) weakSelf = self;
     //add dictionaries or json data to the archive, calling completeArchive when done
@@ -361,7 +364,8 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
             {
                 ORKFileResult * fileResult = (ORKFileResult*) result;
                 NSString *translatedFilename = [ORKFileResult filenameForFileResultIdentifier:fileResult.identifier stepIdentifier:stepResult.identifier];
-                if (fileResult.fileURL) {
+                if (fileResult.fileURL && ![filenames containsObject:translatedFilename]) {
+                    [filenames addObject:translatedFilename];
                     [strongSelf.archive insertDataAtURLIntoArchive:fileResult.fileURL fileName:translatedFilename];
                 }
             }


### PR DESCRIPTION
don't add a 2nd file with the same name to an archive

Note: I wasn't able to repro this with an iPhone 6. Tried tapping and going back and then tapping more. Tried going back and then minimizing and then returning. 

This PR should resolve the issue, altho some data might be lost. The file creation process is RK though, so not sure how far we want to dig into what is going on.
