### PR TITLE
Bridge 908 Overlapping tasks

### DIFF
--- a/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
+++ b/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
@@ -297,7 +297,7 @@ static NSString * const kQueueName = @"APCScheduler CoreData query queue";
     // Check that expires date does not exist or is later than the start of today
     // Check that finishedDate does not exist or is later than the start of today
     NSPredicate *filterForThisDay = [NSPredicate predicateWithFormat:
-                                     @"(%K < %@) && (%K == nil OR %K.length == 0 OR %K >= %@) && (%K == nil OR %K.length == 0 OR %K >= %@)",
+                                     @"(%K < %@) && (%K == nil OR %K.length == 0 OR %K > %@) && (%K == nil OR %K.length == 0 OR %K >= %@)",
                                      NSStringFromSelector (@selector (taskScheduledFor)),           // -[APCTask taskScheduledFor]
                                      midnightThisEvening,
                                      NSStringFromSelector (@selector (taskExpires)),           // -[APCTask taskExpires]

--- a/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
+++ b/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
@@ -297,7 +297,7 @@ static NSString * const kQueueName = @"APCScheduler CoreData query queue";
     // Check that expires date does not exist or is later than the start of today
     // Check that finishedDate does not exist or is later than the start of today
     NSPredicate *filterForThisDay = [NSPredicate predicateWithFormat:
-                                     @"(%K <= %@) && (%K == nil OR %K.length == 0 OR %K >= %@) && (%K == nil OR %K.length == 0 OR %K >= %@)",
+                                     @"(%K < %@) && (%K == nil OR %K.length == 0 OR %K >= %@) && (%K == nil OR %K.length == 0 OR %K >= %@)",
                                      NSStringFromSelector (@selector (taskScheduledFor)),           // -[APCTask taskScheduledFor]
                                      midnightThisEvening,
                                      NSStringFromSelector (@selector (taskExpires)),           // -[APCTask taskExpires]


### PR DESCRIPTION
next day's tasks were allowed with <= midnight tomorrow rather than <. This should fix that oversight. 
Similarly, stuff that expired at midnight this morning were still showing for that day. also fixed.

This should resolve mPower issues as well.
