### PR TITLE
bump lookahead for scheduledActivities to 4 (max)

### DIFF
--- a/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
+++ b/APCAppCore/APCAppCore/Library/Scheduler/APCScheduler.m
@@ -371,7 +371,7 @@ static NSString * const kQueueName = @"APCScheduler CoreData query queue";
              Bounce over to the Bridge SDK's thread, call the server, and then come
              back to our thread a while later.
              */
-            [SBBComponent (SBBActivityManager) getScheduledActivitiesForDaysAhead:3
+            [SBBComponent (SBBActivityManager) getScheduledActivitiesForDaysAhead:4
                                           withCompletion:^(SBBResourceList *tasksList,
                                                            NSError *errorFetchingTasks)
              {


### PR DESCRIPTION
Figured this made sense, especially if there is a period where we aren't getting tasks that have expired in the last 24 hours.
