### PR TITLE
Feature/BRIDGE-946 provide schema revision

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -739,6 +739,7 @@
 		045D0CBD1BBAFDC500330C7E /* APCModel 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "APCModel 8.xcdatamodel"; sourceTree = "<group>"; };
 		0494397F1B8FC04000CAE23C /* APCDownloadDataViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCDownloadDataViewController.h; sourceTree = "<group>"; };
 		049439801B8FC04000CAE23C /* APCDownloadDataViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCDownloadDataViewController.m; sourceTree = "<group>"; };
+		049E4CC31BE1829900E45E4D /* APCModel 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "APCModel 9.xcdatamodel"; sourceTree = "<group>"; };
 		04FB64451BB4883900D0A50D /* APCTaskImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCTaskImporter.h; sourceTree = "<group>"; };
 		04FB64461BB4883900D0A50D /* APCTaskImporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCTaskImporter.m; sourceTree = "<group>"; };
 		04FB64491BB4A11A00D0A50D /* APCModel 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "APCModel 7.xcdatamodel"; sourceTree = "<group>"; };
@@ -4165,6 +4166,7 @@
 		F5F128981A2F78490015982C /* APCModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				049E4CC31BE1829900E45E4D /* APCModel 9.xcdatamodel */,
 				045D0CBD1BBAFDC500330C7E /* APCModel 8.xcdatamodel */,
 				04FB64491BB4A11A00D0A50D /* APCModel 7.xcdatamodel */,
 				366345791B1F84F0003CC0EF /* APCModel 6.xcdatamodel */,
@@ -4174,7 +4176,7 @@
 				36469C321AA1650F00C10CA7 /* APCModel 3.xcdatamodel */,
 				F5F128991A2F78490015982C /* APCModel.xcdatamodel */,
 			);
-			currentVersion = 045D0CBD1BBAFDC500330C7E /* APCModel 8.xcdatamodel */;
+			currentVersion = 049E4CC31BE1829900E45E4D /* APCModel 9.xcdatamodel */;
 			path = APCModel.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/.xccurrentversion
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>APCModel 8.xcdatamodel</string>
+	<string>APCModel 9.xcdatamodel</string>
 </dict>
 </plist>

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/APCModel 9.xcdatamodel/contents
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCModel.xcdatamodeld/APCModel 9.xcdatamodel/contents
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="8195" systemVersion="14F27" minimumToolsVersion="Xcode 4.3">
+    <entity name="APCDBStatus" representedClassName="APCDBStatus" syncable="YES">
+        <attribute name="status" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerDailyDosageRecord" representedClassName="APCMedTrackerDailyDosageRecord" syncable="YES">
+        <attribute name="dateThisRecordRepresents" attributeType="Date" indexed="YES" syncable="YES"/>
+        <attribute name="numberOfDosesTakenForThisDate" attributeType="Integer 16" minValueString="0" defaultValueString="0" syncable="YES"/>
+        <relationship name="prescriptionIAmBasedOn" maxCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescription" inverseName="actualDosesTaken" inverseEntity="APCMedTrackerPrescription" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerInflatableItem" representedClassName="APCMedTrackerInflatableItem" syncable="YES">
+        <attribute name="name" attributeType="String" minValueString="1" indexed="YES" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerMedication" representedClassName="APCMedTrackerMedication" parentEntity="APCMedTrackerInflatableItem" syncable="YES">
+        <relationship name="prescriptionsWhereIAmUsed" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescription" inverseName="medication" inverseEntity="APCMedTrackerPrescription" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerPossibleDosage" representedClassName="APCMedTrackerPossibleDosage" parentEntity="APCMedTrackerInflatableItem" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="Float" minValueString="0" syncable="YES"/>
+        <relationship name="prescriptionsWhereIAmUsed" optional="YES" toMany="YES" minCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescription" inverseName="dosage" inverseEntity="APCMedTrackerPrescription" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerPrescription" representedClassName="APCMedTrackerPrescription" syncable="YES">
+        <attribute name="dateStartedUsing" attributeType="Date" syncable="YES"/>
+        <attribute name="dateStoppedUsing" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="didStopUsingOnDoctorsOrders" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="numberOfTimesPerDay" attributeType="Integer 16" minValueString="0" defaultValueString="0" syncable="YES"/>
+        <attribute name="zeroBasedDaysOfTheWeek" attributeType="String" syncable="YES"/>
+        <relationship name="actualDosesTaken" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCMedTrackerDailyDosageRecord" inverseName="prescriptionIAmBasedOn" inverseEntity="APCMedTrackerDailyDosageRecord" syncable="YES"/>
+        <relationship name="color" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescriptionColor" inverseName="prescriptionsWhereIAmUsed" inverseEntity="APCMedTrackerPrescriptionColor" syncable="YES"/>
+        <relationship name="dosage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerPossibleDosage" inverseName="prescriptionsWhereIAmUsed" inverseEntity="APCMedTrackerPossibleDosage" syncable="YES"/>
+        <relationship name="medication" maxCount="1" deletionRule="Nullify" destinationEntity="APCMedTrackerMedication" inverseName="prescriptionsWhereIAmUsed" inverseEntity="APCMedTrackerMedication" syncable="YES"/>
+    </entity>
+    <entity name="APCMedTrackerPrescriptionColor" representedClassName="APCMedTrackerPrescriptionColor" parentEntity="APCMedTrackerInflatableItem" syncable="YES">
+        <attribute name="alphaAsFloat" attributeType="Float" minValueString="0" maxValueString="1" defaultValueString="1" syncable="YES"/>
+        <attribute name="blueAsInteger" attributeType="Integer 16" minValueString="0" maxValueString="255" defaultValueString="50" syncable="YES"/>
+        <attribute name="greenAsInteger" optional="YES" attributeType="Integer 16" minValueString="0" maxValueString="255" defaultValueString="50" syncable="YES"/>
+        <attribute name="naturalSortOrder" optional="YES" attributeType="Integer 16" minValueString="0" defaultValueString="0" indexed="YES" syncable="YES"/>
+        <attribute name="redAsInteger" optional="YES" attributeType="Integer 16" minValueString="0" maxValueString="255" defaultValueString="50" syncable="YES"/>
+        <relationship name="prescriptionsWhereIAmUsed" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCMedTrackerPrescription" inverseName="color" inverseEntity="APCMedTrackerPrescription" syncable="YES"/>
+    </entity>
+    <entity name="APCResult" representedClassName="APCResult" syncable="YES">
+        <attribute name="archiveFilename" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="metaData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="resultSummary" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskRunID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="uploaded" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <relationship name="task" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="APCTask" inverseName="results" inverseEntity="APCTask" syncable="YES"/>
+    </entity>
+    <entity name="APCStoredUserData" representedClassName="APCStoredUserData" syncable="YES">
+        <attribute name="allowContact" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="biologicalSex" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="birthDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="bloodType" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="consentSignatureDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="consentSignatureImage" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="consentSignatureName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="customSurveyQuestion" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dailyScalesCompletionCounter" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="ethnicity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="glucoseLevels" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasHeartDisease" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="homeLocationAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="homeLocationLat" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="homeLocationLong" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="medicalConditions" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="medications" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="profileImage" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES" syncable="YES"/>
+        <attribute name="secondaryInfoSaved" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="serverConsented" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="sharedOptionSelection" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="sleepTime" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskCompletion" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="userConsented" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="wakeUpTime" optional="YES" attributeType="Date" syncable="YES"/>
+    </entity>
+    <entity name="APCTask" representedClassName="APCTask" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="sortString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskClassName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskCompletionTimeString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskContentFileName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskDescription" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="taskExpires" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskFinished" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskGuid" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskHRef" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskID" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="taskIsOptional" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="taskScheduledFor" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskSchemaRevision" optional="YES" attributeType="Double" defaultValueString="0" syncable="YES"/>
+        <attribute name="taskStarted" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taskType" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="taskVersionDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="taskVersionName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <relationship name="results" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="APCResult" inverseName="task" inverseEntity="APCResult" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="APCDBStatus" positionX="-1341" positionY="72" width="171" height="58"/>
+        <element name="APCMedTrackerDailyDosageRecord" positionX="-1188" positionY="621" width="216" height="88"/>
+        <element name="APCMedTrackerInflatableItem" positionX="-965" positionY="1080" width="299" height="58"/>
+        <element name="APCMedTrackerMedication" positionX="-1260" positionY="935" width="180" height="58"/>
+        <element name="APCMedTrackerPossibleDosage" positionX="-1269" positionY="758" width="216" height="73"/>
+        <element name="APCMedTrackerPrescription" positionX="-938" positionY="764" width="218" height="178"/>
+        <element name="APCMedTrackerPrescriptionColor" positionX="-666" positionY="729" width="207" height="133"/>
+        <element name="APCResult" positionX="-1359" positionY="297" width="171" height="210"/>
+        <element name="APCStoredUserData" positionX="-1593" positionY="72" width="200" height="435"/>
+        <element name="APCTask" positionX="-873" positionY="71" width="207" height="360"/>
+    </elements>
+</model>

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask+Bridge.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask+Bridge.m
@@ -115,6 +115,7 @@
                     self.taskTitle = sbbSurvey.name;
                     self.taskVersionName = sbbSurvey.guid;
                     self.taskVersionDate = sbbSurvey.createdOn;
+                    self.taskSchemaRevision = sbbSurvey.schemaRevision;
                     self.rkTask = [APCTask rkTaskFromSBBSurvey:survey];
                     NSError * saveError;
                     [self saveToPersistentStore:&saveError];

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask.h
@@ -51,6 +51,7 @@
 @property (nonatomic, retain) NSString * taskID;
 @property (nonatomic, retain) NSNumber * taskIsOptional;
 @property (nonatomic, retain) NSDate * taskScheduledFor;
+@property (nonatomic, retain) NSNumber * taskSchemaRevision;
 @property (nonatomic, retain) NSDate * taskStarted;
 @property (nonatomic, retain) NSString * taskTitle;
 @property (nonatomic, retain) NSNumber * taskType;

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask.m
@@ -50,6 +50,7 @@
 @dynamic taskID;
 @dynamic taskIsOptional;
 @dynamic taskScheduledFor;
+@dynamic taskSchemaRevision;
 @dynamic taskStarted;
 @dynamic taskTitle;
 @dynamic taskType;

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.m
@@ -50,6 +50,7 @@ static NSString * kFileInfoContentTypeKey           = @"contentType";
 static NSString * kTaskRunKey                       = @"taskRun";
 static NSString * kSurveyCreatedOnKey               = @"surveyCreatedOn";
 static NSString * kSurveyGuidKey                    = @"surveyGuid";
+static NSString * kSchemaRevisionKey                = @"schemaRevision";
 static NSString * kFilesKey                         = @"files";
 static NSString * kAppNameKey                       = @"appName";
 static NSString * kAppVersionKey                    = @"appVersion";
@@ -198,7 +199,11 @@ static NSString * kJsonInfoFilename                 = @"info.json";
         [self.infoDict setObject:[APCUtilities phoneInfo] forKey:kPhoneInfoKey];
         [self.infoDict setObject:[NSUUID new].UUIDString forKey:kTaskRunKey];
         [self.infoDict setObject:self.reference forKey:kItemKey];
+        if (self.task.taskSchemaRevision) {
+            [self.infoDict setObject:self.task.taskSchemaRevision forKey:kSchemaRevisionKey];
+        }
         if ([self.task.taskType isEqualToNumber:@(APCTaskTypeSurveyTask)]) {
+            // Survey schema is better matched by created date and survey guid
             [self.infoDict setObject:self.task.taskVersionName forKey:kSurveyGuidKey];
             NSString *isoCreatedString = [self.task.taskVersionDate ISO8601String];
             [self.infoDict setObject:isoCreatedString forKey:kSurveyCreatedOnKey];

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.h
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.h
@@ -78,6 +78,7 @@
 - (void)addSpatialSpanMemoryResultsToArchive:(ORKSpatialSpanMemoryResult *) __unused result;
 - (void)addTappingResultsToArchive:(ORKTappingIntervalResult *)__unused result;
 - (APCSignUpPermissionsType)requiredPermission;
+- (void) updateSchemaRevision;
 
 - (void) archiveResults;
 

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.m
@@ -54,6 +54,9 @@ static NSString * const kFileInfoNameKey            = @"filename";
 static NSString * const kFileInfoTimeStampKey       = @"timestamp";
 static NSString * const kFileInfoContentTypeKey     = @"contentType";
 
+// Upload constants
+static NSInteger        kDefaultSchemaRevision      = 1;
+
 //    ORK Result Base Class property keys
 //
 static NSString * const kIdentifierKey              = @"identifier";
@@ -134,6 +137,7 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
     APCBaseTaskViewController * controller = orkTask ? [[self alloc] initWithTask:orkTask taskRunUUID:taskRunUUID] : nil;
     controller.scheduledTask = scheduledTask;
     controller.delegate = controller;
+    [controller updateSchemaRevision];
     [[APCScheduler defaultScheduler] startTask:scheduledTask];
     
     return  controller;
@@ -168,6 +172,14 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
 {
     //To be overridden by child classes
     return nil;
+}
+
+- (void) updateSchemaRevision
+{
+    // To be overridden by child classes for non default schema revision #s
+    if (self.scheduledTask) {
+        self.scheduledTask.taskSchemaRevision = [NSNumber numberWithInteger:kDefaultSchemaRevision];
+    }
 }
 
 - (void)viewDidLoad
@@ -336,6 +348,7 @@ NSString * NSStringFromORKTaskViewControllerFinishReason (ORKTaskViewControllerF
 {
     //get a fresh archive
     self.archive = [[APCDataArchive alloc]initWithReference:self.task.identifier task:self.scheduledTask];
+    
     // Track filenames. Occasionally RK spit out 2 files with the same name which causes trouble on the backend
     // if the archive has 2 files named the same. See BRIDGE-789.
     NSMutableSet *filenames = [NSMutableSet new];

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/CommonTaskVCs/GenericSurveyTaskViewController/APCGenericSurveyTaskViewController.m
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/CommonTaskVCs/GenericSurveyTaskViewController/APCGenericSurveyTaskViewController.m
@@ -48,4 +48,10 @@
     return  [scheduledTask rkTask];
 }
 
+- (void) updateSchemaRevision
+{
+    // Don't make changes here. For surveys, the schemaRevision is updated from bridge when
+    // the survey is loaded.
+}
+
 @end


### PR DESCRIPTION
This should allow app and task specific view controllers to specify the schema version to use when completing the activity and uploading the data. The revision is used to pair the uploaded data with the correct schema for that data. Surveys from bridge provide the schema revision when the survey is downloaded but tasks need to hardcode it inside the appropriate view controller since data format is determined inside the app.
