### PR TITLE
Bridge 936

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTaskGroup.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTaskGroup.h
@@ -171,30 +171,6 @@
 @property (nonatomic, strong) NSDate *expirationDate;
 
 /**
- Returns YES if this is the expiration date for this task appearance.
-
- For example, if a schedule says a task will be visible throughout the year
- 2015, is only visible once a month, and is visible for 3 days at a time before
- it vanishes, like this:
-
- @code
- startsOn:  2015-01-01
- endsOn:    2015-12-31
- interval:  P1M
- expires:   P3D    <----
- @endcode
-
- ...then -expiresToday will be YES if -date is the last of those 3 days.  If
- the user doesn't do it by that third day, it's considered "not completed" or
- "skipped."  For each day through that third day, the task will appear in the
- user's list of "Today" activities.  On the 4th day, the task will appear in
- the user's list of "Incomplete from Yesterday" activities.
- 
- @see lastLegalDate
- */
-@property (nonatomic, assign) BOOL expiresToday;
-
-/**
  Returns YES if -requiredCompletedTasks.count is greater
  than -countOfRequiredTasksForThisTimeRange.
  */
@@ -211,5 +187,8 @@
 
 - (instancetype)       initWithTasks: (NSArray *) tasks
                     forScheduledDate: (NSDate *) scheduledDate;
+
+
+- (BOOL) expiresOnOrBeforeDate:(NSDate *) date;
 
 @end

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTaskGroup.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTaskGroup.m
@@ -199,7 +199,7 @@ static NSDateFormatter *debugDateFormatter = nil;
 
 - (BOOL) expiresOnOrBeforeDate:(NSDate *) date
 {
-    return _expirationDate != nil && (_expirationDate.startOfDay <= date.startOfDay);
+    return _expirationDate != nil && (_expirationDate <= date);
 }
 
 - (NSString *) description

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTaskGroup.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTaskGroup.m
@@ -103,7 +103,6 @@ static NSDateFormatter *debugDateFormatter = nil;
         _scheduledDate = nil;
         _appearanceDate = nil;
         _expirationDate = nil;
-        _expiresToday = NO;
     }
 
     return self;
@@ -135,7 +134,6 @@ static NSDateFormatter *debugDateFormatter = nil;
         _appearanceDate = scheduledDate;
         _scheduledDate = scheduledDate;
         _expirationDate = _task.taskExpires;
-        _expiresToday = _expirationDate != nil && [_expirationDate.startOfDay isEqualToDate: _appearanceDate.startOfDay];
     }
     
     return self;
@@ -199,6 +197,11 @@ static NSDateFormatter *debugDateFormatter = nil;
     return latestCompletionDate;
 }
 
+- (BOOL) expiresOnOrBeforeDate:(NSDate *) date
+{
+    return _expirationDate != nil && (_expirationDate.startOfDay <= date.startOfDay);
+}
+
 - (NSString *) description
 {
     NSString *result = nil;
@@ -214,12 +217,11 @@ static NSDateFormatter *debugDateFormatter = nil;
         [dates appendFormat: @"%@, ", scheduledTask.updatedAt];
     }
 
-    result = [NSString stringWithFormat: @"TaskGroup: %@ | %@ | vcToShow: %@ | %@ | expires today: %@ | tasks: %@ required, %@ completed, %@ remaining, %@ gratuitous completed, most recent completed on %@",
+    result = [NSString stringWithFormat: @"TaskGroup: %@ | %@ | vcToShow: %@ | %@ | tasks: %@ required, %@ completed, %@ remaining, %@ gratuitous completed, most recent completed on %@",
               self.task.taskTitle,
               self.task.taskID,
               self.task.taskClassName,
               dates,
-              self.expiresToday ? @"YES" : @"NO",
               @(self.totalRequiredTasksForThisTimeRange),
               @(self.requiredCompletedTasks.count),
               @(self.requiredRemainingTasks.count),

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
@@ -590,7 +590,7 @@ static CGFloat const kTableViewSectionHeaderHeight = 77;
              }
              else if (section.isYesterdaySection)
              {
-                 [section reduceToIncompleteTasksOnTheirLastLegalDay];
+                 [section reduceToIncompleteExpiredTasks];
              }
              
              if (section.taskGroups.count)

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewSection.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewSection.h
@@ -58,13 +58,13 @@
 /**
  Former name for -reduceToIncompleteTasksOnTheirLastLegalDay.
  */
-- (void) removeFullyCompletedTasks  __attribute__((deprecated("Please use -reduceToIncompleteTasksOnTheirLastLegalDay instead.")));
+- (void) removeFullyCompletedTasks  __attribute__((deprecated("Please use -reduceToIncompleteExpiredTasks.")));
 
 /**
  Used after fetching the tasks for "yesterday," as perceived by the user,
  and converting resulting section to a "here's the stuff you didn't finish"
  section.
  */
-- (void) reduceToIncompleteTasksOnTheirLastLegalDay;
+- (void) reduceToIncompleteExpiredTasks;
 
 @end

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewSection.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewSection.m
@@ -188,10 +188,10 @@ static NSString * const kAPCSectionHeaderDateFormatToday        = @"eeee, MMMM d
  */
 - (void) removeFullyCompletedTasks
 {
-    [self reduceToIncompleteTasksOnTheirLastLegalDay];
+    [self reduceToIncompleteExpiredTasks];
 }
 
-- (void) reduceToIncompleteTasksOnTheirLastLegalDay
+- (void) reduceToIncompleteExpiredTasks
 {
     NSIndexSet *indexesOfTaskGroupsWeWant = [self.taskGroups indexesOfObjectsPassingTest: ^BOOL (APCTaskGroup *taskGroup,
                                                                                                  NSUInteger __unused taskGroupIndex,

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewSection.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewSection.m
@@ -198,7 +198,7 @@ static NSString * const kAPCSectionHeaderDateFormatToday        = @"eeee, MMMM d
                                                                                                  BOOL __unused *stopIterating) {
         BOOL keepThisOne = NO;
         
-        if (! taskGroup.isFullyCompleted && taskGroup.expiresToday)
+        if (! taskGroup.isFullyCompleted && [taskGroup expiresOnOrBeforeDate:self.today])
         {
             keepThisOne = YES;
         }


### PR DESCRIPTION
This fixes incorrect filtering of yesterdays tasks and should result in the yesterdays task section showing up when appropriate. Basically, the expiresToday setter was just comparing the date it was scheduled for and the expiration date. It doesn't actually have enough information there to know what "Today" is and if it expiresToday or really what it should be doing. This property was then getting checked by the ViewSection. Since the ViewSection does know about yesterday and today and things like that, it can supply the dates.
