### PR TITLE
Expose APCThankYouViewController, Add ability to hide sharing step

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		0871A3941A8F4244002EA80D /* APCDashboardFoodInsightTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0871A3921A8F4244002EA80D /* APCDashboardFoodInsightTableViewCell.m */; };
 		087255C01ABA390500586492 /* APCJSONSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 087255BE1ABA390500586492 /* APCJSONSerializer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		087255C11ABA390500586492 /* APCJSONSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 087255BF1ABA390500586492 /* APCJSONSerializer.m */; };
-		087468061AA691A400BE2572 /* APCThankYouViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 087468041AA691A400BE2572 /* APCThankYouViewController.h */; };
+		087468061AA691A400BE2572 /* APCThankYouViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 087468041AA691A400BE2572 /* APCThankYouViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		087468071AA691A400BE2572 /* APCThankYouViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 087468051AA691A400BE2572 /* APCThankYouViewController.m */; };
 		0875C3D81A797A7B00CE50FB /* APCButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 0875C3D61A797A7B00CE50FB /* APCButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0875C3D91A797A7B00CE50FB /* APCButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 0875C3D71A797A7B00CE50FB /* APCButton.m */; };
@@ -3191,7 +3191,6 @@
 				F5B947C71A73272C0034C522 /* NSObject+Helper.h in Headers */,
 				747307101A96E1DE0071D863 /* APCCMS.h in Headers */,
 				7423AB5B1AA3FFD8004A325A /* APCConsentRedirector.h in Headers */,
-				087468061AA691A400BE2572 /* APCThankYouViewController.h in Headers */,
 				081A477A1A93EC4700E13148 /* APCBadgeLabel.h in Headers */,
 				F5F12A891A2F78490015982C /* APCTableViewItem.h in Headers */,
 				F5F12AC31A2F78490015982C /* APCLearnMasterViewController.h in Headers */,
@@ -3293,6 +3292,7 @@
 				F5F12AAE1A2F78490015982C /* APCSignUpInfoViewController.h in Headers */,
 				36257FBD1AA714B60060B95A /* CMMotionActivity+Helper.h in Headers */,
 				F5C363601A40E21000113129 /* APCSmartSurveyTask.h in Headers */,
+				087468061AA691A400BE2572 /* APCThankYouViewController.h in Headers */,
 				6C7346081A7ECD3B00DA9CD8 /* APCConsentTaskViewController.h in Headers */,
 				F5B9462A1A7309A20034C522 /* ZZChannelOutput.h in Headers */,
 				F5F12AB41A2F78490015982C /* APCSignUpPermissionsViewController.h in Headers */,

--- a/APCAppCore/APCAppCore/APCAppCore.h
+++ b/APCAppCore/APCAppCore/APCAppCore.h
@@ -130,6 +130,7 @@ FOUNDATION_EXPORT const unsigned char APCAppCoreVersionString[];
 #import <APCAppCore/APCPasscodeViewController.h>
 #import <APCAppCore/APCConsentTaskViewController.h>
 #import <APCAppCore/APCWebViewController.h>
+#import <APCAppCore/APCThankYouViewController.h>
 
 /*--------------------------
  Dashboard ViewControllers

--- a/APCAppCore/APCAppCore/Consent/APCConsentTask.m
+++ b/APCAppCore/APCAppCore/Consent/APCConsentTask.m
@@ -45,6 +45,7 @@
 static NSString*    kDocumentHtmlTag                    = @"htmlDocument";
 static NSString*    kInvestigatorShortDescriptionTag    = @"investigatorShortDescription";
 static NSString*    kInvestigatorLongDescriptionTag     = @"investigatorLongDescription";
+static NSString*    kHideSharingStepTag                 = @"hideSharingStep";
 static NSString*    kHtmlContentTag                     = @"htmlContent";
 static NSString*    kIdentifierTag                      = @"identifier";
 static NSString*    kPromptTag                          = @"prompt";
@@ -100,6 +101,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
 @property (nonatomic, strong) NSArray*          documentSections;
 
 //  Sharing
+@property (nonatomic, assign) BOOL              hideSharingStep;
 @property (nonatomic, copy)   NSString*         investigatorShortDescription;
 @property (nonatomic, copy)   NSString*         investigatorLongDescription;
 @property (nonatomic, copy)   NSString*         sharingHtmlLearnMoreContent;
@@ -185,10 +187,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     
     _visualStep  = [[ORKVisualConsentStep alloc] initWithIdentifier:@"visual"
                                                            document:_consentDocument];
-    _sharingStep = [[ORKConsentSharingStep alloc] initWithIdentifier:kSharingTag
-                                        investigatorShortDescription:self.investigatorShortDescription
-                                         investigatorLongDescription:self.investigatorLongDescription
-                                       localizedLearnMoreHTMLContent:self.sharingHtmlLearnMoreContent];
+
     
     APCAppDelegate* delegate = (APCAppDelegate*) [UIApplication sharedApplication].delegate;
     BOOL disableSignatureInConsent = delegate.disableSignatureInConsent;
@@ -205,7 +204,14 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     
     NSMutableArray* consentSteps = [[NSMutableArray alloc] init];
     [consentSteps addObject:_visualStep];
-    [consentSteps addObject:_sharingStep];
+    
+    if (!self.hideSharingStep) {
+        _sharingStep = [[ORKConsentSharingStep alloc] initWithIdentifier:kSharingTag
+                                            investigatorShortDescription:self.investigatorShortDescription
+                                             investigatorLongDescription:self.investigatorLongDescription
+                                           localizedLearnMoreHTMLContent:self.sharingHtmlLearnMoreContent];
+        [consentSteps addObject:_sharingStep];
+    }
     
     _indexOfFirstCustomStep = consentSteps.count;
     [consentSteps addObjectsFromArray:customSteps];
@@ -512,6 +518,10 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     
     self.investigatorLongDescription = [properties objectForKey:kInvestigatorLongDescriptionTag];
     NSAssert(self.investigatorLongDescription != nil && [self.investigatorLongDescription isKindOfClass:[NSString class]], @"Improper type for Investigator Long Description");
+    
+    if ([properties valueForKey:kHideSharingStepTag] != nil) {
+        self.hideSharingStep = [properties valueForKey:kHideSharingStepTag];
+    }
 
     NSString*   htmlContent = [properties objectForKey:kHtmlContentTag];
     if (htmlContent != nil)


### PR DESCRIPTION
APCThankYouViewController was not visible publicly, unlike most (All?) of the other VCs in the Onboarding flow. Made it work like the others so it can be referenced/used in APH VCs

In FPHS, football players aren't supposed to see the step where they choose a sharing level since they default to the lower setting. These changes make it possible to avoid having that step added to the consent ORKSteps by setting hideSharingStep to true in the json that is used to assemble the steps.
