### PR TITLE
Enable localization of onboarding HTML content

### DIFF
--- a/APCAppCore/APCAppCore/Consent/APCConsentTask.m
+++ b/APCAppCore/APCAppCore/Consent/APCConsentTask.m
@@ -499,7 +499,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     
     if (documentHtmlContent != nil)
     {
-        NSString*   path    = [[NSBundle mainBundle] pathForResource:documentHtmlContent ofType:@"html" inDirectory:@"HTMLContent"];
+        NSString*   path    = [[NSBundle mainBundle] pathForResource:documentHtmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", documentHtmlContent);
         
         if (path != nil)
@@ -527,7 +527,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     NSString*   htmlContent = [properties objectForKey:kHtmlContentTag];
     if (htmlContent != nil)
     {
-        NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html" inDirectory:@"HTMLContent"];
+        NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
         
         NSError*    error   = nil;
@@ -790,7 +790,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
         
         if (htmlContent != nil)
         {
-            NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html" inDirectory:@"HTMLContent"];
+            NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html"];
             NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
             
             NSError*    error   = nil;

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -425,7 +425,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     
     if (documentHtmlContent != nil && htmlContent != nil)
     {
-        NSString*   path    = [[NSBundle mainBundle] pathForResource:documentHtmlContent ofType:@"html" inDirectory:@"HTMLContent"];
+        NSString*   path    = [[NSBundle mainBundle] pathForResource:documentHtmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", documentHtmlContent);
         
         NSError*    error   = nil;
@@ -492,7 +492,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
         
         if (htmlContent != nil)
         {
-            NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html" inDirectory:@"HTMLContent"];
+            NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html"];
             NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
             
             NSError*    error   = nil;

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
@@ -55,7 +55,7 @@
     
     self.title = self.studyDetails.caption;
     
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:self.studyDetails.detailText ofType:@"html" inDirectory:@"HTMLContent"];
+    NSString *filePath = [[NSBundle mainBundle] pathForResource:self.studyDetails.detailText ofType:@"html"];
     NSURL *targetURL = [NSURL URLWithString:filePath];
     NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
     self.webView.delegate = self;

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
@@ -237,8 +237,8 @@ static NSString *kConsentEmailSubject = @"Consent Document";
     } else {
         APCStudyOverviewCollectionViewCell *webViewCell = (APCStudyOverviewCollectionViewCell *)[collectionView dequeueReusableCellWithReuseIdentifier:kAPCStudyOverviewCollectionViewCellIdentifier forIndexPath:indexPath];
         
-        NSString *filePath = [[NSBundle mainBundle] pathForResource: studyDetails.detailText ofType:@"html" inDirectory:@"HTMLContent"];
-        NSAssert(filePath, @"Expecting file \"%@.html\" to be present in the \"HTMLContent\" directory, but didn't find it", studyDetails.detailText);
+        NSString *filePath = [[NSBundle mainBundle] pathForResource: studyDetails.detailText ofType:@"html"];
+        NSAssert(filePath, @"Expecting file \"%@.html\" to be present in Resources, but didn't find it", studyDetails.detailText);
         NSURL *targetURL = [NSURL URLWithString:filePath];
         NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
         [webViewCell.webView loadRequest:request];

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -1619,7 +1619,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 - (void)showPrivacyPolicy
 {
     APCWebViewController *webViewController = [[UIStoryboard storyboardWithName:@"APCOnboarding" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWebViewController"];
-    NSString *filePath = [[NSBundle mainBundle] pathForResource: @"PrivacyPolicy" ofType:@"html" inDirectory:@"HTMLContent"];
+    NSString *filePath = [[NSBundle mainBundle] pathForResource: @"PrivacyPolicy" ofType:@"html"];
     NSURL *targetURL = [NSURL URLWithString:filePath];
     NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
     webViewController.title = NSLocalizedStringWithDefaultValue(@"Privacy Policy", @"APCAppCore", APCBundle(), @"Privacy Policy", @"");


### PR DESCRIPTION
Xcode doesn't handle localization of resources in subdirectories very well (e.g., the HTML resources in RK apps having been added as a folder en masse rather than letting Xcode create a new group for them based on the folder name, so that they end up in an HTML subfolder within the app's Resources folder rather than in <region>.lproj subfolders directly in the Resources folder).

This goes along with the corresponding change in the app projects, i.e. remove the HTML directory from the project (removing references only) and re-add it, this time allowing Xcode to create a new HTML group rather than adding the directory itself.
