### PR TITLE
make navBar not translucent to match other tabs

### DIFF
--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -906,6 +906,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 - (void)setupAppearance
 {
     [self.navigationController.navigationBar setBarTintColor:[UIColor appPrimaryNavBarColor]];
+    self.navigationController.navigationBar.translucent = NO;
     
     [self.nameTextField setTextColor:[UIColor blackColor]];
     


### PR DESCRIPTION
This translucent setter is in the other profile tabs, was just missed in this one. Not relevant when white, very visible/relevant when it is another color.
