### PR TITLE
Updates to AppCore to support resource and storyboard loading that is not hardcoded.

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -710,6 +710,8 @@
 		F5F12B2B1A2F864B0015982C /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F5F12B2A1A2F864B0015982C /* libz.dylib */; };
 		F5F12B2D1A2F86550015982C /* libarchive.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F5F12B2C1A2F86550015982C /* libarchive.dylib */; };
 		F5F12B2F1A2F86600015982C /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F5F12B2E1A2F86600015982C /* libbz2.dylib */; };
+		FF0B4A961C29D98C00224EF7 /* APCScene.h in Headers */ = {isa = PBXBuildFile; fileRef = FF0B4A941C29D98C00224EF7 /* APCScene.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF0B4A971C29D98C00224EF7 /* APCScene.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0B4A951C29D98C00224EF7 /* APCScene.m */; };
 		FF44E50A1C1A3BB200F07DA9 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF44E5091C1A3BB200F07DA9 /* BridgeSDK.framework */; };
 		FF44E50D1C1B585900F07DA9 /* APCTaskResultArchiver.h in Headers */ = {isa = PBXBuildFile; fileRef = FF44E50B1C1B585900F07DA9 /* APCTaskResultArchiver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF44E50E1C1B585900F07DA9 /* APCTaskResultArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FF44E50C1C1B585900F07DA9 /* APCTaskResultArchiver.m */; };
@@ -1458,6 +1460,8 @@
 		F5F12B2A1A2F864B0015982C /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		F5F12B2C1A2F86550015982C /* libarchive.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libarchive.dylib; path = usr/lib/libarchive.dylib; sourceTree = SDKROOT; };
 		F5F12B2E1A2F86600015982C /* libbz2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.dylib; path = usr/lib/libbz2.dylib; sourceTree = SDKROOT; };
+		FF0B4A941C29D98C00224EF7 /* APCScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCScene.h; sourceTree = "<group>"; };
+		FF0B4A951C29D98C00224EF7 /* APCScene.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCScene.m; sourceTree = "<group>"; };
 		FF44E5091C1A3BB200F07DA9 /* BridgeSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BridgeSDK.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/Parkinson-dphbgsbdqdzhcbeketqhdiecbfyz/Build/Products/Debug-iphoneos/BridgeSDK.framework"; sourceTree = "<group>"; };
 		FF44E50B1C1B585900F07DA9 /* APCTaskResultArchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCTaskResultArchiver.h; sourceTree = "<group>"; };
 		FF44E50C1C1B585900F07DA9 /* APCTaskResultArchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCTaskResultArchiver.m; sourceTree = "<group>"; };
@@ -2693,6 +2697,8 @@
 				F5F1293E1A2F78490015982C /* APCOnboarding.m */,
 				5B0432A51A322BEE000DC9ED /* APCOnboardingTask.h */,
 				5B0432A61A322BEE000DC9ED /* APCOnboardingTask.m */,
+				FF0B4A941C29D98C00224EF7 /* APCScene.h */,
+				FF0B4A951C29D98C00224EF7 /* APCScene.m */,
 				F5F1293F1A2F78490015982C /* APCSignUpTask.h */,
 				F5F129401A2F78490015982C /* APCSignUpTask.m */,
 				5B04329D1A318AA2000DC9ED /* APCSignInTask.h */,
@@ -3339,6 +3345,7 @@
 				7BEC13D61AA3AA5B00CA316C /* APCFitnessAllocation.h in Headers */,
 				369E27ED1A96B7A200D35DFA /* APCMedicationColor.h in Headers */,
 				369E27EF1A96B7A200D35DFA /* APCMedicationDataStorageEngine.h in Headers */,
+				FF0B4A961C29D98C00224EF7 /* APCScene.h in Headers */,
 				369B47551A853E8500777639 /* APCUtilities.h in Headers */,
 				F5F12A711A2F78490015982C /* APCConcentricProgressView.h in Headers */,
 				5B7EA0231A44C21200924DEE /* APCFormTextField.h in Headers */,
@@ -3788,6 +3795,7 @@
 				CFFDED741A95731F00B25581 /* APCMedicationTrackerCalendarWeeklyView.m in Sources */,
 				5B0601CE1AE79B50009D6D65 /* APCFeedTableViewCell.m in Sources */,
 				7B6C8CB81AA26ECE0007B560 /* APCConsentBooleanQuestion.m in Sources */,
+				FF0B4A971C29D98C00224EF7 /* APCScene.m in Sources */,
 				F5F12A941A2F78490015982C /* APCStudyDetailsViewController.m in Sources */,
 				5B0601C31AE79AE0009D6D65 /* APCFeedParser.m in Sources */,
 				F5F12A8A1A2F78490015982C /* APCTableViewItem.m in Sources */,

--- a/APCAppCore/APCAppCore/APCAppCore.h
+++ b/APCAppCore/APCAppCore/APCAppCore.h
@@ -290,6 +290,7 @@ FOUNDATION_EXPORT const unsigned char APCAppCoreVersionString[];
 #import <APCAppCore/APCKeychainStore+Passcode.h>
 #import <APCAppCore/APCPresentAnimator.h>
 #import <APCAppCore/APCFadeAnimator.h>
+#import <APCAppCore/APCScene.h>
 #import <APCAppCore/APCScoring.h>
 #import <APCAppCore/APCDeviceHardware.h>
 #import <APCAppCore/APCInsights.h>

--- a/APCAppCore/APCAppCore/Consent/APCConsentTask.m
+++ b/APCAppCore/APCAppCore/Consent/APCConsentTask.m
@@ -463,9 +463,9 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
 
 - (void)loadFromJson:(NSString*)fileName
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    APCAppDelegate *appDelegate = [APCAppDelegate sharedAppDelegate];
     
-    NSString*       filePath = [resourceBundle pathForResource:fileName ofType:@"json"];
+    NSString*       filePath = [appDelegate pathForResource:fileName ofType:@"json"];
     NSAssert(filePath != nil, @"Unable to location file with Consent Section in main bundle");
     
     NSData*         fileContent = [NSData dataWithContentsOfFile:filePath];
@@ -496,14 +496,14 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
 
 - (void)loadDocumentProperties:(NSDictionary*)properties
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    APCAppDelegate *appDelegate = [APCAppDelegate sharedAppDelegate];
     
     NSString*   documentHtmlContent = [properties objectForKey:kDocumentHtmlTag];
     NSAssert(documentHtmlContent == nil || documentHtmlContent != nil && [documentHtmlContent isKindOfClass:[NSString class]], @"Improper Document HTML Content type");
     
     if (documentHtmlContent != nil)
     {
-        NSString*   path    = [resourceBundle pathForResource:documentHtmlContent ofType:@"html"];
+        NSString*   path    = [appDelegate pathForResource:documentHtmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", documentHtmlContent);
         
         if (path != nil)
@@ -531,7 +531,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     NSString*   htmlContent = [properties objectForKey:kHtmlContentTag];
     if (htmlContent != nil)
     {
-        NSString*   path    = [resourceBundle pathForResource:htmlContent ofType:@"html"];
+        NSString*   path    = [appDelegate pathForResource:htmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
         
         NSError*    error   = nil;
@@ -742,7 +742,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     static NSString*   kSectionAnimationUrl    = @"sectionAnimationUrl";
     
     NSMutableArray* consentSections = [NSMutableArray arrayWithCapacity:properties.count];
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    APCAppDelegate *appDelegate = [APCAppDelegate sharedAppDelegate];
     
     for (NSDictionary* section in properties)
     {
@@ -796,7 +796,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
         if (htmlContent != nil)
         {
             
-            NSString*   path    = [resourceBundle pathForResource:htmlContent ofType:@"html"];
+            NSString*   path    = [appDelegate pathForResource:htmlContent ofType:@"html"];
             NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
             
             NSError*    error   = nil;
@@ -824,7 +824,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
             {
                 nameWithScaleFactor = [nameWithScaleFactor stringByAppendingString:@"@2x"];
             }
-            NSURL*      url   = [resourceBundle URLForResource:nameWithScaleFactor withExtension:@"m4v"];
+            NSURL*      url   = [[appDelegate resourceBundle] URLForResource:nameWithScaleFactor withExtension:@"m4v"];
             NSError*    error = nil;
             
             NSAssert([url checkResourceIsReachableAndReturnError:&error], @"Animation file--%@--not reachable: %@", animationUrl, error);

--- a/APCAppCore/APCAppCore/Consent/APCConsentTask.m
+++ b/APCAppCore/APCAppCore/Consent/APCConsentTask.m
@@ -463,7 +463,9 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
 
 - (void)loadFromJson:(NSString*)fileName
 {
-    NSString*       filePath = [[NSBundle mainBundle] pathForResource:fileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    
+    NSString*       filePath = [resourceBundle pathForResource:fileName ofType:@"json"];
     NSAssert(filePath != nil, @"Unable to location file with Consent Section in main bundle");
     
     NSData*         fileContent = [NSData dataWithContentsOfFile:filePath];
@@ -494,12 +496,14 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
 
 - (void)loadDocumentProperties:(NSDictionary*)properties
 {
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    
     NSString*   documentHtmlContent = [properties objectForKey:kDocumentHtmlTag];
     NSAssert(documentHtmlContent == nil || documentHtmlContent != nil && [documentHtmlContent isKindOfClass:[NSString class]], @"Improper Document HTML Content type");
     
     if (documentHtmlContent != nil)
     {
-        NSString*   path    = [[NSBundle mainBundle] pathForResource:documentHtmlContent ofType:@"html"];
+        NSString*   path    = [resourceBundle pathForResource:documentHtmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", documentHtmlContent);
         
         if (path != nil)
@@ -527,7 +531,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     NSString*   htmlContent = [properties objectForKey:kHtmlContentTag];
     if (htmlContent != nil)
     {
-        NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html"];
+        NSString*   path    = [resourceBundle pathForResource:htmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
         
         NSError*    error   = nil;
@@ -738,6 +742,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
     static NSString*   kSectionAnimationUrl    = @"sectionAnimationUrl";
     
     NSMutableArray* consentSections = [NSMutableArray arrayWithCapacity:properties.count];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
     
     for (NSDictionary* section in properties)
     {
@@ -790,7 +795,8 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
         
         if (htmlContent != nil)
         {
-            NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html"];
+            
+            NSString*   path    = [resourceBundle pathForResource:htmlContent ofType:@"html"];
             NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
             
             NSError*    error   = nil;
@@ -818,7 +824,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
             {
                 nameWithScaleFactor = [nameWithScaleFactor stringByAppendingString:@"@2x"];
             }
-            NSURL*      url   = [[NSBundle mainBundle] URLForResource:nameWithScaleFactor withExtension:@"m4v"];
+            NSURL*      url   = [resourceBundle URLForResource:nameWithScaleFactor withExtension:@"m4v"];
             NSError*    error = nil;
             
             NSAssert([url checkResourceIsReachableAndReturnError:&error], @"Animation file--%@--not reachable: %@", animationUrl, error);

--- a/APCAppCore/APCAppCore/Library/APCTaskImporter.m
+++ b/APCAppCore/APCAppCore/Library/APCTaskImporter.m
@@ -39,6 +39,7 @@
 #import "NSDate+Helper.h"
 #import "NSError+APCAdditions.h"
 #import "NSManagedObject+APCHelper.h"
+#import "APCAppDelegate.h"
 
 // ---------------------------------------------------------
 #pragma mark - Constants
@@ -275,7 +276,8 @@ static NSArray *legalTimeSpecifierFormats = nil;
 {
     id <ORKTask> rkSurvey = nil;
     
-    NSString *surveyFilePath = [[NSBundle mainBundle] pathForResource: surveyContentFileBaseName
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *surveyFilePath = [resourceBundle pathForResource: surveyContentFileBaseName
                                                                ofType: kAPCFileExtension_JSON];
     
     if (! surveyFilePath)
@@ -405,7 +407,8 @@ static NSArray *legalTimeSpecifierFormats = nil;
         
         // Set up TaskId->TaskViewController dictionary
         // TODO: move this init stuff out of a situation where it will be called many times
-        NSString *filePath = [[NSBundle mainBundle] pathForResource:kTaskIdToViewControllerMappingJSON ofType:@"json"];
+        NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+        NSString *filePath = [resourceBundle pathForResource:kTaskIdToViewControllerMappingJSON ofType:@"json"];
         NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath
                                                                encoding:NSUTF8StringEncoding
                                                                   error:NULL];

--- a/APCAppCore/APCAppCore/Library/APCTaskImporter.m
+++ b/APCAppCore/APCAppCore/Library/APCTaskImporter.m
@@ -276,8 +276,7 @@ static NSArray *legalTimeSpecifierFormats = nil;
 {
     id <ORKTask> rkSurvey = nil;
     
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *surveyFilePath = [resourceBundle pathForResource: surveyContentFileBaseName
+    NSString *surveyFilePath = [[APCAppDelegate sharedAppDelegate] pathForResource: surveyContentFileBaseName
                                                                ofType: kAPCFileExtension_JSON];
     
     if (! surveyFilePath)
@@ -407,8 +406,7 @@ static NSArray *legalTimeSpecifierFormats = nil;
         
         // Set up TaskId->TaskViewController dictionary
         // TODO: move this init stuff out of a situation where it will be called many times
-        NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-        NSString *filePath = [resourceBundle pathForResource:kTaskIdToViewControllerMappingJSON ofType:@"json"];
+        NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:kTaskIdToViewControllerMappingJSON ofType:@"json"];
         NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath
                                                                encoding:NSUTF8StringEncoding
                                                                   error:NULL];

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCTaskResultArchiver.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCTaskResultArchiver.m
@@ -32,6 +32,7 @@
 //
 
 #import "APCTaskResultArchiver.h"
+#import "APCAppDelegate.h"
 #import "APCLog.h"
 #import "APCDataArchive.h"
 #import "APCTask.h"
@@ -396,8 +397,9 @@ static  NSString  *const  kSpatialSpanMemoryTouchSampleIsCorrectKey     = @"Memo
 - (NSDictionary *)filenameTranslationDictionary
 {
     if (_filenameTranslationDictionary == nil) {
-        [self setFilenameTranslationDictionaryWithJSONFileAtPath:
-         [[NSBundle mainBundle] pathForResource:APCDefaultTranslationFilename ofType:kJSONExtension]];;
+        NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+        NSString *path = [resourceBundle pathForResource:APCDefaultTranslationFilename ofType:kJSONExtension];
+        [self setFilenameTranslationDictionaryWithJSONFileAtPath:path];
     }
     return _filenameTranslationDictionary;
 }

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCTaskResultArchiver.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCTaskResultArchiver.m
@@ -397,8 +397,7 @@ static  NSString  *const  kSpatialSpanMemoryTouchSampleIsCorrectKey     = @"Memo
 - (NSDictionary *)filenameTranslationDictionary
 {
     if (_filenameTranslationDictionary == nil) {
-        NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-        NSString *path = [resourceBundle pathForResource:APCDefaultTranslationFilename ofType:kJSONExtension];
+        NSString *path = [[APCAppDelegate sharedAppDelegate] pathForResource:APCDefaultTranslationFilename ofType:kJSONExtension];
         [self setFilenameTranslationDictionaryWithJSONFileAtPath:path];
     }
     return _filenameTranslationDictionary;

--- a/APCAppCore/APCAppCore/Library/FeedParser/APCNewsFeedManager.m
+++ b/APCAppCore/APCAppCore/Library/FeedParser/APCNewsFeedManager.m
@@ -35,6 +35,7 @@
 #import "APCNewsFeedManager.h"
 #import "APCFeedParser.h"
 #import "APCLog.h"
+#import "APCAppDelegate.h"
 
 NSString * const kAPCNewsFeedUpdateNotification = @"APCNewsFeedUpdateNotification";
 
@@ -128,7 +129,8 @@ static NSString * const kAPCBlogUrlKey   = @"BlogUrlKey";
 
 - (NSString *)blogUrlFromJSONFile:(NSString *)jsonFileName
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:jsonFileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/Library/FeedParser/APCNewsFeedManager.m
+++ b/APCAppCore/APCAppCore/Library/FeedParser/APCNewsFeedManager.m
@@ -129,8 +129,7 @@ static NSString * const kAPCBlogUrlKey   = @"BlogUrlKey";
 
 - (NSString *)blogUrlFromJSONFile:(NSString *)jsonFileName
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
@@ -202,8 +202,9 @@ FOUNDATION_EXPORT NSString *const kHKWorkoutTypeKey;
 FOUNDATION_EXPORT NSString * const kPasswordKey;
 FOUNDATION_EXPORT NSString * const kNumberOfMinutesForPasscodeKey;
 
-FOUNDATION_EXPORT NSUInteger     const kAPCActivitiesTabIndex;
-FOUNDATION_EXPORT NSUInteger     const kAPCNewsFeedTabIndex;
+FOUNDATION_EXPORT NSInteger     const kAPCActivitiesTabTag;
+FOUNDATION_EXPORT NSInteger     const kAPCNewsFeedTabTag;
+FOUNDATION_EXPORT NSInteger     const kAPCProfileTabTag;
 
 FOUNDATION_EXPORT NSInteger      const kAPCSigninErrorCode_NotSignedIn;
 FOUNDATION_EXPORT NSUInteger     const kAPCSigninNumRetriesBeforePause;

--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
@@ -185,8 +185,9 @@ NSString *const kHKWorkoutTypeKey       = @"HKWorkoutType";
 NSString * const kPasswordKey                    = @"Password";
 NSString * const kNumberOfMinutesForPasscodeKey  = @"NumberOfMinutesForPasscodeKey";
 
-NSUInteger     const kAPCActivitiesTabIndex                                 = 0;
-NSUInteger     const kAPCNewsFeedTabIndex                                   = 2;
+NSInteger     const kAPCActivitiesTabTag                                   = 100;
+NSInteger     const kAPCNewsFeedTabTag                                     = 102;
+NSInteger     const kAPCProfileTabTag                                      = 103;
 
 NSInteger      const kAPCSigninErrorCode_NotSignedIn                        = 404;
 NSUInteger     const kAPCSigninNumRetriesBeforePause                        = 10;

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.m
@@ -301,8 +301,7 @@ NSString * gTaskReminderDelayMessage;
 }
 
 - (NSString *)studyName {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:@"StudyOverview" ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:@"StudyOverview" ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.m
@@ -301,7 +301,8 @@ NSString * gTaskReminderDelayMessage;
 }
 
 - (NSString *)studyName {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"StudyOverview" ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:@"StudyOverview" ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
@@ -35,6 +35,7 @@
 #import "APCConstants.h"
 #import "APCLog.h"
 #import "APCParameters+Settings.h"
+#import "APCAppDelegate.h"
 
 
 // Private constants
@@ -260,8 +261,8 @@ NSString *const kBypassServerProperty                   = @"bypassServer";
     //This is used for unit testing
     //        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     //        NSString *bundlePath = [bundle pathForResource:fileNameAndExtension[0] ofType:fileNameAndExtension[1]];
-    
-    NSString *bundlePath = [[NSBundle mainBundle] pathForResource:fileNameAndExtension[0] ofType:fileNameAndExtension[1]];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *bundlePath = [resourceBundle pathForResource:fileNameAndExtension[0] ofType:fileNameAndExtension[1]];
     
     BOOL           fileExists = [[NSFileManager defaultManager] fileExistsAtPath:bundlePath];
     if (fileExists) {

--- a/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
+++ b/APCAppCore/APCAppCore/Library/Parameters/APCParameters.m
@@ -261,8 +261,7 @@ NSString *const kBypassServerProperty                   = @"bypassServer";
     //This is used for unit testing
     //        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     //        NSString *bundlePath = [bundle pathForResource:fileNameAndExtension[0] ofType:fileNameAndExtension[1]];
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *bundlePath = [resourceBundle pathForResource:fileNameAndExtension[0] ofType:fileNameAndExtension[1]];
+    NSString *bundlePath = [[APCAppDelegate sharedAppDelegate] pathForResource:fileNameAndExtension[0] ofType:fileNameAndExtension[1]];
     
     BOOL           fileExists = [[NSFileManager defaultManager] fileExistsAtPath:bundlePath];
     if (fileExists) {

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
@@ -42,6 +42,13 @@
 extern NSUInteger   const kTheEntireDataModelOfTheApp;
 static NSString*    const kDatabaseName                     = @"db.sqlite";
 
+// Default tab controller tab keys
+extern NSString *const kDashBoardStoryBoardKey;
+extern NSString *const kLearnStoryBoardKey;
+extern NSString *const kActivitiesStoryBoardKey;
+extern NSString *const kHealthProfileStoryBoardKey;
+extern NSString *const kNewsFeedStoryBoardKey;
+
 @class APCDataSubstrate, APCDataMonitor, APCScheduler, APCPasscodeViewController, APCTasksReminderManager, APCPassiveDataCollector, APCFitnessAllocation;
 
 @interface APCAppDelegate : UIResponder <UIApplicationDelegate, APCOnboardingManagerProvider, APCPasscodeViewControllerDelegate, SBBBridgeAppDelegate>
@@ -96,6 +103,9 @@ static NSString*    const kDatabaseName                     = @"db.sqlite";
 - (NSString *) applicationDocumentsDirectory;
 - (NSUInteger)obtainPreviousVersion;
 
+//Default bundle for resources and storyboards
+- (NSBundle*)resourceBundle;
+
 //SetupMethods
 - (void) setUpInitializationOptions;
 - (void) setUpAppAppearance;
@@ -125,5 +135,9 @@ static NSString*    const kDatabaseName                     = @"db.sqlite";
 - (NSDate*)applicationBecameActiveDate;
 
 - (void)updateNewsFeedBadgeCount;
+
+
+// List of the tabs to use to setup the tabbar
+- (NSMutableArray <APCScene *> *)tabBarScenes;
 
 @end

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
@@ -105,6 +105,7 @@ extern NSString *const kNewsFeedStoryBoardKey;
 
 //Default bundle for resources and storyboards
 - (NSBundle*)resourceBundle;
+- (NSString*)pathForResource:(NSString*)resourceName ofType:(NSString*)resourceType;
 
 //SetupMethods
 - (void) setUpInitializationOptions;

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -99,9 +99,18 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     return appDelegate;
 }
 
+/*********************************************************************************/
+#pragma mark - Resource handling
+/*********************************************************************************/
+
 - (NSBundle*)resourceBundle
 {
     return [NSBundle mainBundle];
+}
+
+- (NSString*)pathForResource:(NSString*)resourceName ofType:(NSString*)resourceType
+{
+    return [[self resourceBundle] pathForResource:resourceName ofType:resourceType];
 }
 
 /*********************************************************************************/
@@ -416,7 +425,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     NSString*   kSectionImage           = @"sectionImage";
     NSString*   kSectionAnimationUrl    = @"sectionAnimationUrl";
     
-    NSString*       resource = [[self resourceBundle] pathForResource:self.initializationOptions[kConsentSectionFileNameKey] ofType:@"json"];
+    NSString*       resource = [self pathForResource:self.initializationOptions[kConsentSectionFileNameKey] ofType:@"json"];
     NSAssert(resource != nil, @"Unable to location file with Consent Section in main bundle");
     
     NSData*         consentSectionData = [NSData dataWithContentsOfFile:resource];
@@ -431,7 +440,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     
     if (documentHtmlContent != nil && htmlContent != nil)
     {
-        NSString*   path    = [[self resourceBundle] pathForResource:documentHtmlContent ofType:@"html"];
+        NSString*   path    = [self pathForResource:documentHtmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", documentHtmlContent);
         
         NSError*    error   = nil;
@@ -498,7 +507,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
         
         if (htmlContent != nil)
         {
-            NSString*   path    = [[self resourceBundle] pathForResource:htmlContent ofType:@"html"];
+            NSString*   path    = [self pathForResource:htmlContent ofType:@"html"];
             NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
             
             NSError*    error   = nil;

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -40,6 +40,7 @@
 #import "UIAlertController+Helper.h"
 #import "APCDemographicUploader.h"
 #import "APCConstants.h"
+#import "APCScene.h"
 #import "APCUtilities.h"
 #import "APCCatastrophicErrorViewController.h"
 
@@ -63,11 +64,11 @@ static NSString*    const kDBStatusCurrentVersion           = @"v1.0";
 /*********************************************************************************/
 #pragma mark - Tab bar Constants
 /*********************************************************************************/
-static NSString *const kDashBoardStoryBoardKey     = @"APHDashboard";
-static NSString *const kLearnStoryBoardKey         = @"APCLearn";
-static NSString *const kActivitiesStoryBoardKey    = @"APCActivities";
-static NSString *const kHealthProfileStoryBoardKey = @"APCProfile";
-static NSString *const kNewsFeedStoryBoardKey      = @"APCNewsFeed";
+NSString *const kDashBoardStoryBoardKey     = @"APCDashboard";
+NSString *const kLearnStoryBoardKey         = @"APCLearn";
+NSString *const kActivitiesStoryBoardKey    = @"APCActivities";
+NSString *const kHealthProfileStoryBoardKey = @"APCProfile";
+NSString *const kNewsFeedStoryBoardKey      = @"APCNewsFeed";
 
 /*********************************************************************************/
 #pragma mark - User Defaults Keys
@@ -98,6 +99,10 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     return appDelegate;
 }
 
+- (NSBundle*)resourceBundle
+{
+    return [NSBundle mainBundle];
+}
 
 /*********************************************************************************/
 #pragma mark - App Delegate Methods
@@ -411,7 +416,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     NSString*   kSectionImage           = @"sectionImage";
     NSString*   kSectionAnimationUrl    = @"sectionAnimationUrl";
     
-    NSString*       resource = [[NSBundle mainBundle] pathForResource:self.initializationOptions[kConsentSectionFileNameKey] ofType:@"json"];
+    NSString*       resource = [[self resourceBundle] pathForResource:self.initializationOptions[kConsentSectionFileNameKey] ofType:@"json"];
     NSAssert(resource != nil, @"Unable to location file with Consent Section in main bundle");
     
     NSData*         consentSectionData = [NSData dataWithContentsOfFile:resource];
@@ -426,7 +431,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     
     if (documentHtmlContent != nil && htmlContent != nil)
     {
-        NSString*   path    = [[NSBundle mainBundle] pathForResource:documentHtmlContent ofType:@"html"];
+        NSString*   path    = [[self resourceBundle] pathForResource:documentHtmlContent ofType:@"html"];
         NSAssert(path != nil, @"Unable to locate HTML file: %@", documentHtmlContent);
         
         NSError*    error   = nil;
@@ -493,7 +498,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
         
         if (htmlContent != nil)
         {
-            NSString*   path    = [[NSBundle mainBundle] pathForResource:htmlContent ofType:@"html"];
+            NSString*   path    = [[self resourceBundle] pathForResource:htmlContent ofType:@"html"];
             NSAssert(path != nil, @"Unable to locate HTML file: %@", htmlContent);
             
             NSError*    error   = nil;
@@ -518,7 +523,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
             } else {
                 nameWithScaleFactor = [nameWithScaleFactor stringByAppendingString:@"@2x"];
             }
-            NSURL*      url   = [[NSBundle mainBundle] URLForResource:nameWithScaleFactor withExtension:@"m4v"];
+            NSURL*      url   = [[self resourceBundle] URLForResource:nameWithScaleFactor withExtension:@"m4v"];
             NSError*    error = nil;
             
             NSAssert([url checkResourceIsReachableAndReturnError:&error], @"Animation file--%@--not reachable: %@", animationUrl, error);
@@ -729,23 +734,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
 - (void)newsFeedUpdated:(NSNotification *)__unused notification
 {
     if ([self.window.rootViewController isKindOfClass:[UITabBarController class]]) {
-        UITabBarController *tabBarController = (UITabBarController *)self.window.rootViewController;
-        
-        BOOL newsFeedTab = [self.initializationOptions[kNewsFeedTabKey] boolValue];
-        
-        if (newsFeedTab){
-            NSArray *items = tabBarController.tabBar.items;
-            UITabBarItem *item = items[kAPCNewsFeedTabIndex];
-            
-            NSUInteger unreadPostsCount = [self.dataSubstrate.newsFeedManager unreadPostsCount];
-            NSNumber *unreadValue = @(unreadPostsCount);
-            
-            if (unreadPostsCount != 0) {
-                item.badgeValue = [unreadValue stringValue];
-            } else {
-                item.badgeValue = nil;
-            }
-        }
+        [self updateNewsFeedBadgeCount];
     }
 }
 
@@ -754,8 +743,6 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
 {
     return ([self.initializationOptions[kBridgeEnvironmentKey] integerValue] == SBBEnvironmentStaging) ? [self.initializationOptions[kAppPrefixKey] stringByAppendingString:@"-staging"] :self.initializationOptions[kAppPrefixKey];
 }
-
-
 
 #pragma mark - Other Abstract Implmentations
 - (void) setUpInitializationOptions {/*Abstract Implementation*/}
@@ -800,91 +787,87 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
 #pragma mark - Tab Bar Stuff
 /*********************************************************************************/
 
+- (BOOL)shouldIncludeNewsFeedTab
+{
+    return [self.initializationOptions[kNewsFeedTabKey] boolValue];
+}
+
+- (UITabBarItem * _Nullable)newsFeedTabBarItem
+{
+    NSString *key = NSStringFromSelector(@selector(tag));
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", key, @(kAPCNewsFeedTabTag)];
+    return [[self.tabBarController.tabBar.items filteredArrayUsingPredicate:predicate] firstObject];
+}
+
+
+- (NSMutableArray <APCScene *> *)tabBarScenes
+{
+    NSMutableArray *scenes = [NSMutableArray array];
+
+    // Add the activities scene
+    APCScene *activities = [[APCScene alloc] init];
+    activities.tabBarItem = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Activities", @"APCAppCore", APCBundle(), @"Activities", nil) image:[UIImage imageNamed:@"tab_activities"] selectedImage:[UIImage imageNamed:@"tab_activities_selected"]];
+    activities.tabBarItem.tag = kAPCActivitiesTabTag;
+    activities.storyboardName = kActivitiesStoryBoardKey;
+    activities.bundle = [NSBundle appleCoreBundle];
+    [scenes addObject:activities];
+    
+    // Add the dashboard scene
+    APCScene *dashboard = [[APCScene alloc] init];
+    dashboard.tabBarItem = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Dashboard", @"APCAppCore", APCBundle(), @"Dashboard", nil) image:[UIImage imageNamed:@"tab_dashboard"] selectedImage:[UIImage imageNamed:@"tab_dashboard_selected"]];
+    dashboard.storyboardName = kDashBoardStoryBoardKey;
+    dashboard.bundle = [NSBundle appleCoreBundle];
+    [scenes addObject:dashboard];
+
+    // Add news tab if there is news
+    if ([self shouldIncludeNewsFeedTab]) {
+        APCScene *news = [[APCScene alloc] init];
+        news.tabBarItem = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"News Feed", @"APCAppCore", APCBundle(), @"News Feed", nil) image:[UIImage imageNamed:@"tab_newsfeed"] selectedImage:[UIImage imageNamed:@"tab_newsfeed_selected"]];
+        news.tabBarItem.tag = kAPCNewsFeedTabTag;
+        news.storyboardName = kNewsFeedStoryBoardKey;
+        news.bundle = [NSBundle appleCoreBundle];
+        [scenes addObject:news];
+    }
+    
+    // Add learn tab
+    APCScene *learn = [[APCScene alloc] init];
+    learn.tabBarItem = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Learn", @"APCAppCore", APCBundle(), @"Learn", nil) image:[UIImage imageNamed:@"tab_learn"] selectedImage:[UIImage imageNamed:@"tab_learn_selected"]];
+    learn.storyboardName = kLearnStoryBoardKey;
+    learn.bundle = [NSBundle appleCoreBundle];
+    [scenes addObject:learn];
+    
+    //Profile Tab
+    APCScene *profile = [[APCScene alloc] init];
+    profile.tabBarItem = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Profile", @"APCAppCore", APCBundle(), @"Profile", nil) image:[UIImage imageNamed:@"tab_profile"] selectedImage:[UIImage imageNamed:@"tab_profile_selected"]];
+    profile.tabBarItem.tag = kAPCProfileTabTag;
+    profile.storyboardName = kHealthProfileStoryBoardKey;
+    profile.bundle = [NSBundle appleCoreBundle];
+    [scenes addObject:profile];
+    
+    return scenes;
+}
+
 - (void)showTabBar
 {
     self.tabBarController = [[UITabBarController alloc] init];
-    NSUInteger selectedItemIndex = kAPCActivitiesTabIndex;
+    NSUInteger selectedItemIndex = 0;
     
-    NSMutableArray *tabBarItems = [NSMutableArray new];
+    // Set the view controllers
     NSMutableArray *viewControllers = [NSMutableArray new];
-    
-    {
-        //Activities Tab
-        UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Activities", @"APCAppCore", APCBundle(), @"Activities", nil) image:[UIImage imageNamed:@"tab_activities"] selectedImage:[UIImage imageNamed:@"tab_activities_selected"]];
-        [tabBarItems addObject:item];
-        
-        UIStoryboard *storyboard = [UIStoryboard storyboardWithName:kActivitiesStoryBoardKey bundle:[NSBundle appleCoreBundle]];
-        UIViewController *viewController = [storyboard instantiateInitialViewController];
-        [viewControllers addObject:viewController];
+    for (APCScene *scene in [self tabBarScenes]) {
+        UIViewController *vc = [scene instantiateViewController];
+        [viewControllers addObject:vc];
     }
-    
-    {
-        //Dashboard Tab
-        UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Dashboard", @"APCAppCore", APCBundle(), @"Dashboard", nil) image:[UIImage imageNamed:@"tab_dashboard"] selectedImage:[UIImage imageNamed:@"tab_dashboard_selected"]];
-        [tabBarItems addObject:item];
-        
-        UIStoryboard *storyboard = [UIStoryboard storyboardWithName:kDashBoardStoryBoardKey bundle:[NSBundle mainBundle]];
-        UIViewController *viewController = [storyboard instantiateInitialViewController];
-        [viewControllers addObject:viewController];
-    }
-    
-    BOOL newsFeedTab = [self.initializationOptions[kNewsFeedTabKey] boolValue];
-    if (newsFeedTab) {
-        UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"News Feed", @"APCAppCore", APCBundle(), @"News Feed", nil) image:[UIImage imageNamed:@"tab_newsfeed"] selectedImage:[UIImage imageNamed:@"tab_newsfeed_selected"]];
-        [tabBarItems addObject:item];
-        
-        UIStoryboard *storyboard = [UIStoryboard storyboardWithName:kNewsFeedStoryBoardKey bundle:[NSBundle appleCoreBundle]];
-        UIViewController *viewController = [storyboard instantiateInitialViewController];
-        [viewControllers addObject:viewController];
-    }
-    
-    {
-        //Learn Tab
-        UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Learn", @"APCAppCore", APCBundle(), @"Learn", nil) image:[UIImage imageNamed:@"tab_learn"] selectedImage:[UIImage imageNamed:@"tab_learn_selected"]];
-        [tabBarItems addObject:item];
-        
-        UIStoryboard *storyboard = [UIStoryboard storyboardWithName:kLearnStoryBoardKey bundle:[NSBundle appleCoreBundle]];
-        UIViewController *viewController = [storyboard instantiateInitialViewController];
-        [viewControllers addObject:viewController];
-    }
-    
-    {
-        //Profile Tab
-        UITabBarItem *item = [[UITabBarItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Profile", @"APCAppCore", APCBundle(), @"Profile", nil) image:[UIImage imageNamed:@"tab_profile"] selectedImage:[UIImage imageNamed:@"tab_profile_selected"]];
-        [tabBarItems addObject:item];
-        
-        UIStoryboard *storyboard = [UIStoryboard storyboardWithName:kHealthProfileStoryBoardKey bundle:[NSBundle appleCoreBundle]];
-        UIViewController *viewController = [storyboard instantiateInitialViewController];
-        [viewControllers addObject:viewController];
-    }
-    
     [self.tabBarController setViewControllers:[NSArray arrayWithArray:viewControllers]];
-    
-    NSArray *items = self.tabBarController.tabBar.items;
-    
-    for (NSUInteger i=0; i<items.count; i++) {
-        UITabBarItem *item = items[i];
-        UITabBarItem *tabBarItem = tabBarItems[i];
-        
-        item.image = tabBarItem.image;
-        item.selectedImage = tabBarItem.selectedImage;
-        item.title = tabBarItem.title;
-        item.tag = i;
-        
-        if (i == kAPCNewsFeedTabIndex && newsFeedTab){
-            [self updateNewsFeedBadgeCount];
-        }
+
+    // The tab bar icons take the default tint color from UIView Appearance tintin iOS8. In order to fix this for we are selecting each of the tabs.
+    for (NSUInteger ii = 0; ii < self.tabBarController.viewControllers.count; ii++){
+        [self.tabBarController setSelectedIndex:ii];
     }
     
-    //The tab bar icons take the default tint color from UIView Appearance tintin iOS8. In order to fix this for we are selecting each of the tabs.
-    {
-        [self.tabBarController setSelectedIndex:0];
-        [self.tabBarController setSelectedIndex:1];
-        [self.tabBarController setSelectedIndex:2];
-        [self.tabBarController setSelectedIndex:3];
-        if (newsFeedTab) {
-            [self.tabBarController setSelectedIndex:4];
-        }
+    // Update the news feed badge
+    if ([self shouldIncludeNewsFeedTab]) {
+        [self updateNewsFeedBadgeCount];
     }
     
     [self.tabBarController setSelectedIndex:selectedItemIndex];
@@ -899,10 +882,9 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
         
         NSUInteger  controllerIndex = [tabBarController.viewControllers indexOfObject:viewController];
         
-        BOOL newsFeedTab = [self.initializationOptions[kNewsFeedTabKey] boolValue];
-        NSUInteger indexOfProfileTab = newsFeedTab ? 4 : 3;
+        UITabBarItem *item = self.tabBarController.tabBar.items[controllerIndex];
         
-        if (controllerIndex == indexOfProfileTab)
+        if (item.tag == kAPCProfileTabTag)
         {
             UINavigationController * profileNavigationController = (UINavigationController *) viewController;
             
@@ -913,8 +895,8 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
                 self.profileViewController.delegate = [self profileExtenderDelegate];
             }
         }
-        
-        if(controllerIndex == kAPCNewsFeedTabIndex && newsFeedTab){
+        else if (item.tag == kAPCNewsFeedTabTag)
+        {
             [self updateNewsFeedBadgeCount];
         }
     }
@@ -925,7 +907,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     NSUInteger unreadPostsCount = [self.dataSubstrate.newsFeedManager unreadPostsCount];
     NSNumber *unreadValue = @(unreadPostsCount);
     
-    UITabBarItem *item = self.tabBarController.tabBar.items[kAPCNewsFeedTabIndex];
+    UITabBarItem *item = [self newsFeedTabBarItem];
     
     if (unreadPostsCount != 0) {
         item.badgeValue = [unreadValue stringValue];
@@ -1048,7 +1030,7 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
         self.secureView = [[UIView alloc] initWithFrame:self.window.rootViewController.view.bounds];
         
         UIImage *blurredImage = [viewForSnapshot blurredSnapshot];
-        UIImage *appIcon = [UIImage imageNamed:@"logo_disease_large" inBundle:[NSBundle mainBundle] compatibleWithTraitCollection:nil];
+        UIImage *appIcon = [UIImage imageNamed:@"logo_disease_large" inBundle:[self resourceBundle] compatibleWithTraitCollection:nil];
         UIImageView *blurredImageView = [[UIImageView alloc] initWithImage:blurredImage];
         UIImageView *appIconImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0,0, 180, 180)];
         

--- a/APCAppCore/APCAppCore/Startup/Migration/APCTasksAndSchedulesMigrationUtility.m
+++ b/APCAppCore/APCAppCore/Startup/Migration/APCTasksAndSchedulesMigrationUtility.m
@@ -65,8 +65,7 @@ NSString *const kTasksAndSchedulesJSONFileName   = @"APHTasksAndSchedules";
     self.dataSubstrate  = ((APCAppDelegate *)[UIApplication sharedApplication].delegate).dataSubstrate;
     self.needsMigration = NO;
     
-    NSBundle*       resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString*       resource = [resourceBundle pathForResource:tasksAndSchedulesFileName ofType:@"json"];
+    NSString*       resource = [[APCAppDelegate sharedAppDelegate] pathForResource:tasksAndSchedulesFileName ofType:@"json"];
     NSData*         jsonData = [NSData dataWithContentsOfFile:resource];
     NSError*        error;
     NSDictionary*   taskAndSchedules = [NSJSONSerialization JSONObjectWithData:jsonData

--- a/APCAppCore/APCAppCore/Startup/Migration/APCTasksAndSchedulesMigrationUtility.m
+++ b/APCAppCore/APCAppCore/Startup/Migration/APCTasksAndSchedulesMigrationUtility.m
@@ -65,7 +65,8 @@ NSString *const kTasksAndSchedulesJSONFileName   = @"APHTasksAndSchedules";
     self.dataSubstrate  = ((APCAppDelegate *)[UIApplication sharedApplication].delegate).dataSubstrate;
     self.needsMigration = NO;
     
-    NSString*       resource = [[NSBundle mainBundle] pathForResource:tasksAndSchedulesFileName ofType:@"json"];
+    NSBundle*       resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString*       resource = [resourceBundle pathForResource:tasksAndSchedulesFileName ofType:@"json"];
     NSData*         jsonData = [NSData dataWithContentsOfFile:resource];
     NSError*        error;
     NSDictionary*   taskAndSchedules = [NSJSONSerialization JSONObjectWithData:jsonData

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboarding.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboarding.h
@@ -80,26 +80,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-
-/**
- *  Simple container to hold on to a specific view controller in a storyboard.
- */
-@interface APCScene : NSObject
-
-/** Refers to StoryboardID. */
-@property (nonatomic, strong) NSString *name;
-
-/** The name of the storyboard. */
-@property (nonatomic, strong) NSString *storyboardName;
-
-/** Defaults to the bundle this class resides in. */
-@property (nonatomic, strong) NSBundle *bundle;
-
-- (instancetype)initWithName:(NSString *)name inStoryboard:(NSString *)storyboardName;
-
-/** Instantiates the view controller as defined by this scene. */
-- (nullable UIViewController *)instantiateViewController;
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboarding.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboarding.m
@@ -35,6 +35,7 @@
 #import "APCSignUpTask.h"
 #import "APCSignInTask.h"
 #import "APCLog.h"
+#import "APCScene.h"
 
 
 @interface APCOnboarding ()
@@ -229,28 +230,4 @@
 @end
 
 
-@implementation APCScene
 
-- (nonnull instancetype)initWithName:(NSString *)name inStoryboard:(NSString *)storyboardName {
-    NSParameterAssert([name length] > 0);
-    NSParameterAssert([storyboardName length] > 0);
-    self = [super init];
-    if (self) {
-        self.name = name;
-        self.storyboardName = storyboardName;
-    }
-    return self;
-}
-
-- (nonnull NSBundle *)bundle {
-    if (!_bundle) {
-        _bundle = [NSBundle bundleForClass:[self class]];
-    }
-    return _bundle;
-}
-
-- (nullable UIViewController *)instantiateViewController {
-    return [[UIStoryboard storyboardWithName:self.storyboardName bundle:self.bundle] instantiateViewControllerWithIdentifier:self.name];
-}
-
-@end

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
@@ -36,6 +36,7 @@
 #import "APCPermissionsManager.h"
 #import "APCUserInfoConstants.h"
 #import "APCLog.h"
+#import "APCScene.h"
 
 #import <HealthKit/HealthKit.h>
 

--- a/APCAppCore/APCAppCore/UI/Model/APCScene.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCScene.h
@@ -1,0 +1,64 @@
+//
+//  APCScene.h
+//  APCAppCore
+//
+// Copyright (c) 2015, Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  Simple container to hold on to a specific view controller in a storyboard.
+ */
+@interface APCScene : NSObject
+
+@property (nonatomic, strong) NSString *identifier;
+
+/** Refers to the tabbar item (if applicable) */
+@property (nonatomic, strong) UITabBarItem * _Nullable tabBarItem;
+
+/** Refers to StoryboardID. */
+@property (nonatomic, strong) NSString * _Nullable storyboardId;
+
+/** The name of the storyboard. */
+@property (nonatomic, strong) NSString *storyboardName;
+
+/** Defaults to the bundle this class resides in. */
+@property (nonatomic, strong) NSBundle *bundle;
+
+- (instancetype)initWithName:(NSString *_Nullable)storyboardId inStoryboard:(NSString *)storyboardName;
+
+/** Instantiates the view controller as defined by this scene. */
+- (UIViewController * _Nullable)instantiateViewController;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/APCAppCore/APCAppCore/UI/Model/APCScene.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCScene.m
@@ -1,0 +1,78 @@
+//
+//  APCScene.m
+//  APCAppCore
+//
+// Copyright (c) 2015, Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "APCScene.h"
+
+@implementation APCScene
+
+- (NSString *)identifier {
+    if (_identifier == nil) {
+        _identifier = self.storyboardName;
+    }
+    return _identifier;
+}
+
+- (instancetype)initWithName:(NSString *_Nullable)storyboardId inStoryboard:(NSString *)storyboardName {
+    NSParameterAssert([storyboardName length] > 0);
+    self = [super init];
+    if (self) {
+        _identifier = storyboardName;
+        _storyboardId = storyboardId;
+        _storyboardName = storyboardName;
+    }
+    return self;
+}
+
+- (NSBundle *)bundle {
+    if (!_bundle) {
+        _bundle = [NSBundle bundleForClass:[self class]];
+    }
+    return _bundle;
+}
+
+- (UIViewController * _Nullable)instantiateViewController {
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:self.storyboardName bundle:self.bundle];
+    UIViewController *viewController;
+    if (self.storyboardId != nil) {
+        viewController = [storyboard instantiateViewControllerWithIdentifier:self.storyboardId];
+    }
+    else {
+        viewController = [storyboard instantiateInitialViewController];
+    }
+    if (self.tabBarItem) {
+        viewController.tabBarItem = self.tabBarItem;
+    }
+    return viewController;
+}
+
+@end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
@@ -55,7 +55,8 @@
     
     self.title = self.studyDetails.caption;
     
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:self.studyDetails.detailText ofType:@"html"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:self.studyDetails.detailText ofType:@"html"];
     NSURL *targetURL = [NSURL URLWithString:filePath];
     NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
     self.webView.delegate = self;

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyDetailsViewController.m
@@ -55,8 +55,7 @@
     
     self.title = self.studyDetails.caption;
     
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:self.studyDetails.detailText ofType:@"html"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:self.studyDetails.detailText ofType:@"html"];
     NSURL *targetURL = [NSURL URLWithString:filePath];
     NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
     self.webView.delegate = self;

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
@@ -237,7 +237,8 @@ static NSString *kConsentEmailSubject = @"Consent Document";
     } else {
         APCStudyOverviewCollectionViewCell *webViewCell = (APCStudyOverviewCollectionViewCell *)[collectionView dequeueReusableCellWithReuseIdentifier:kAPCStudyOverviewCollectionViewCellIdentifier forIndexPath:indexPath];
         
-        NSString *filePath = [[NSBundle mainBundle] pathForResource: studyDetails.detailText ofType:@"html"];
+        NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+        NSString *filePath = [resourceBundle pathForResource: studyDetails.detailText ofType:@"html"];
         NSAssert(filePath, @"Expecting file \"%@.html\" to be present in Resources, but didn't find it", studyDetails.detailText);
         NSURL *targetURL = [NSURL URLWithString:filePath];
         NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
@@ -283,7 +284,8 @@ static NSString *kConsentEmailSubject = @"Consent Document";
 - (NSArray *)studyDetailsFromJSONFile:(NSString *)jsonFileName
 {
     NSParameterAssert(jsonFileName);
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:jsonFileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
     NSAssert(filePath, @"Must include file \"%@.json\" in bundle", jsonFileName);
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
@@ -384,7 +386,8 @@ static NSString *kConsentEmailSubject = @"Consent Document";
 {
     APCTableViewStudyDetailsItem *studyDetails = (APCTableViewStudyDetailsItem *)[self itemForIndexPath:[self.collectionView indexPathForCell:cell]];
     
-    NSURL *fileURL = [NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:studyDetails.videoName ofType:@"mp4"]];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSURL *fileURL = [NSURL fileURLWithPath:[resourceBundle pathForResource:studyDetails.videoName ofType:@"mp4"]];
     NSAssert(fileURL, @"Must include the consent video with filename \"%@.mp4\" in the app bundle", studyDetails.videoName);
     APCIntroVideoViewController *introVideoViewController = [[APCIntroVideoViewController alloc] initWithContentURL:fileURL];
     
@@ -467,7 +470,8 @@ static NSString *kConsentEmailSubject = @"Consent Document";
 
 - (NSData *)PDFDataOfConsent
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"consent" ofType:@"pdf"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:@"consent" ofType:@"pdf"];
     NSAssert(filePath, @"Must include the consent PDF with filename \"consent.pdf\" in the app bundle");
     NSData *fileData = [NSData dataWithContentsOfFile:filePath];
     NSAssert(fileData, @"Failed to create an NSData representation of \"consent.pdf\"");

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewCollectionViewController.m
@@ -237,8 +237,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
     } else {
         APCStudyOverviewCollectionViewCell *webViewCell = (APCStudyOverviewCollectionViewCell *)[collectionView dequeueReusableCellWithReuseIdentifier:kAPCStudyOverviewCollectionViewCellIdentifier forIndexPath:indexPath];
         
-        NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-        NSString *filePath = [resourceBundle pathForResource: studyDetails.detailText ofType:@"html"];
+        NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource: studyDetails.detailText ofType:@"html"];
         NSAssert(filePath, @"Expecting file \"%@.html\" to be present in Resources, but didn't find it", studyDetails.detailText);
         NSURL *targetURL = [NSURL URLWithString:filePath];
         NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
@@ -284,8 +283,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
 - (NSArray *)studyDetailsFromJSONFile:(NSString *)jsonFileName
 {
     NSParameterAssert(jsonFileName);
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:jsonFileName ofType:@"json"];
     NSAssert(filePath, @"Must include file \"%@.json\" in bundle", jsonFileName);
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
@@ -386,8 +384,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
 {
     APCTableViewStudyDetailsItem *studyDetails = (APCTableViewStudyDetailsItem *)[self itemForIndexPath:[self.collectionView indexPathForCell:cell]];
     
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSURL *fileURL = [NSURL fileURLWithPath:[resourceBundle pathForResource:studyDetails.videoName ofType:@"mp4"]];
+    NSURL *fileURL = [NSURL fileURLWithPath:[[APCAppDelegate sharedAppDelegate] pathForResource:studyDetails.videoName ofType:@"mp4"]];
     NSAssert(fileURL, @"Must include the consent video with filename \"%@.mp4\" in the app bundle", studyDetails.videoName);
     APCIntroVideoViewController *introVideoViewController = [[APCIntroVideoViewController alloc] initWithContentURL:fileURL];
     
@@ -470,8 +467,7 @@ static NSString *kConsentEmailSubject = @"Consent Document";
 
 - (NSData *)PDFDataOfConsent
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:@"consent" ofType:@"pdf"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:@"consent" ofType:@"pdf"];
     NSAssert(filePath, @"Must include the consent PDF with filename \"consent.pdf\" in the app bundle");
     NSData *fileData = [NSData dataWithContentsOfFile:filePath];
     NSAssert(fileData, @"Failed to create an NSData representation of \"consent.pdf\"");

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewViewController.m
@@ -250,8 +250,7 @@ static NSString * const kStudyOverviewCellIdentifier = @"kStudyOverviewCellIdent
 
 - (NSArray *)studyDetailsFromJSONFile:(NSString *)jsonFileName
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCStudyOverviewViewController.m
@@ -250,7 +250,8 @@ static NSString * const kStudyOverviewCellIdentifier = @"kStudyOverviewCellIdent
 
 - (NSArray *)studyDetailsFromJSONFile:(NSString *)jsonFileName
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:jsonFileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCTermsAndConditionsViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCTermsAndConditionsViewController.m
@@ -84,8 +84,7 @@
 
 - (NSString *)surveyFromJSONFile:(NSString *)jsonFileName
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCTermsAndConditionsViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCTermsAndConditionsViewController.m
@@ -84,7 +84,8 @@
 
 - (NSString *)surveyFromJSONFile:(NSString *)jsonFileName
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:jsonFileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
@@ -704,7 +704,7 @@ static CGFloat const kTableViewSectionHeaderHeight = 77;
 
     for (UITabBarItem *item in tabBar.items)
     {
-        if (item.tag == (NSInteger) kAPCActivitiesTabIndex)
+        if (item.tag == (NSInteger) kAPCActivitiesTabTag)
         {
             activitiesTab = item;
             break;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Dashboard/APCDashboard.storyboard
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Dashboard/APCDashboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -20,14 +20,12 @@
                         <subviews>
                             <imageView alpha="0.5" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="XRL-yF-y8l">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <animations/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yjk-1l-u9o">
                                 <rect key="frame" x="18" y="235" width="284" height="320"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Steps" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ncx-b9-JHk">
                                         <rect key="frame" x="15" y="8" width="255" height="29"/>
-                                        <animations/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="255" id="pdj-mM-68C"/>
                                         </constraints>
@@ -37,14 +35,12 @@
                                     </label>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ck3-5B-WrV">
                                         <rect key="frame" x="13" y="46" width="257" height="209"/>
-                                        <animations/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bhg-Eh-jX8" customClass="APCButton">
                                         <rect key="frame" x="70" y="273" width="145" height="35"/>
-                                        <animations/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="145" id="LZd-fr-TnH"/>
                                             <constraint firstAttribute="height" constant="35" id="t6w-yM-Vb9"/>
@@ -59,7 +55,6 @@
                                         </connections>
                                     </button>
                                 </subviews>
-                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstItem="Ncx-b9-JHk" firstAttribute="top" secondItem="Yjk-1l-u9o" secondAttribute="top" constant="8" id="1Ig-a2-Ktq"/>
@@ -81,7 +76,6 @@
                                 </variation>
                             </view>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="Yjk-1l-u9o" firstAttribute="leading" secondItem="njs-Xo-Qfk" secondAttribute="leadingMargin" constant="2" id="6OC-MS-gag"/>
@@ -120,7 +114,6 @@
                         <subviews>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bordered" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="HcH-CO-AjL">
                                 <rect key="frame" x="4" y="13" width="504" height="29"/>
-                                <animations/>
                                 <segments>
                                     <segment title="5D"/>
                                     <segment title="1W"/>
@@ -135,7 +128,6 @@
                             </segmentedControl>
                             <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pA1-tk-u1e">
                                 <rect key="frame" x="0.0" y="54" width="568" height="1"/>
-                                <animations/>
                                 <color key="backgroundColor" red="0.94509803921568625" green="0.94509803921568625" blue="0.94509803921568625" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="BEW-0b-tAd"/>
@@ -143,17 +135,14 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XCp-55-xj3" customClass="APCLineGraphView">
                                 <rect key="frame" x="4" y="95" width="564" height="217"/>
-                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3ZX-FY-u6V" customClass="APCDiscreteGraphView">
                                 <rect key="frame" x="4" y="100" width="564" height="212"/>
-                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kio-T5-Y4A">
                                 <rect key="frame" x="522" y="8" width="38" height="38"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="38" id="8Wy-bg-Tle"/>
                                     <constraint firstAttribute="width" constant="38" id="kjb-Pz-ne0"/>
@@ -167,7 +156,6 @@
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cnr-qn-gof" userLabel="Tint View">
                                 <rect key="frame" x="0.0" y="55" width="4" height="265"/>
-                                <animations/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.2666666667" blue="0.3803921569" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="4" id="WZs-dt-sHS"/>
@@ -175,7 +163,6 @@
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Steps" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GW7-fg-rzK">
                                 <rect key="frame" x="16" y="56" width="130" height="33"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="130" id="DI5-A9-phx"/>
                                     <constraint firstAttribute="height" constant="33" id="i2d-xh-pac"/>
@@ -186,7 +173,6 @@
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Average: " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AEN-nF-Kgn">
                                 <rect key="frame" x="154" y="61" width="180" height="26"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="26" id="e63-0L-iPl"/>
                                     <constraint firstAttribute="width" constant="180" id="yUH-J8-C7m"/>
@@ -197,7 +183,6 @@
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PCx-rQ-uiY">
                                 <rect key="frame" x="225" y="60" width="25" height="25"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="25" id="BUR-h1-9iK"/>
                                     <constraint firstAttribute="width" constant="25" id="qrz-vx-GCk"/>
@@ -205,7 +190,6 @@
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8iC-5C-XBs">
                                 <rect key="frame" x="154" y="64" width="329" height="21"/>
-                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="plF-Se-7g6"/>
                                     <constraint firstAttribute="width" constant="329" id="wlh-wY-H2C"/>
@@ -215,7 +199,6 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="3ZX-FY-u6V" firstAttribute="leading" secondItem="NSh-Ou-wJu" secondAttribute="leading" constant="4" id="BY3-Fu-6Dc"/>

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Learn/APCLearnMasterViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Learn/APCLearnMasterViewController.m
@@ -199,8 +199,7 @@ static NSString *kreturnControlOfTaskDelegate = @"returnControlOfTaskDelegate";
 
 - (NSArray *)studyDetailsFromJSONFile:(NSString *)jsonFileName
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Learn/APCLearnMasterViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Learn/APCLearnMasterViewController.m
@@ -199,7 +199,8 @@ static NSString *kreturnControlOfTaskDelegate = @"returnControlOfTaskDelegate";
 
 - (NSArray *)studyDetailsFromJSONFile:(NSString *)jsonFileName
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:jsonFileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -1344,8 +1344,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 
 - (void)setupDataFromJSONFile:(NSString *)jsonFileName
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;
@@ -1620,9 +1619,8 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 
 - (void)showPrivacyPolicy
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
     APCWebViewController *webViewController = [[UIStoryboard storyboardWithName:@"APCOnboarding" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWebViewController"];
-    NSString *filePath = [resourceBundle pathForResource: @"PrivacyPolicy" ofType:@"html"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource: @"PrivacyPolicy" ofType:@"html"];
     NSURL *targetURL = [NSURL URLWithString:filePath];
     NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
     webViewController.title = NSLocalizedStringWithDefaultValue(@"Privacy Policy", @"APCAppCore", APCBundle(), @"Privacy Policy", @"");
@@ -1654,7 +1652,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         UIAlertAction *pdfAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"View PDF", @"APCAppCore", APCBundle(), @"View PDF", @"View PDF") style:UIAlertActionStyleDefault handler:^(UIAlertAction * __unused action) {
             
             APCWebViewController *webViewController = [[UIStoryboard storyboardWithName:@"APCOnboarding" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWebViewController"];
-            NSString *filePath = [[appDelegate resourceBundle] pathForResource:@"consent" ofType:@"pdf"];
+            NSString *filePath = [appDelegate pathForResource:@"consent" ofType:@"pdf"];
             NSData *data = [NSData dataWithContentsOfFile:filePath];
             [webViewController.webView setDataDetectorTypes:UIDataDetectorTypeAll];
             webViewController.title = NSLocalizedStringWithDefaultValue(@"Consent", @"APCAppCore", APCBundle(), @"Consent", @"Consent");
@@ -1671,7 +1669,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     if ([consentReviewActions containsObject:kReviewConsentActionVideo]) {
         UIAlertAction *videoAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"Watch Video", @"APCAppCore", APCBundle(), @"Watch Video", @"Watch Video") style:UIAlertActionStyleDefault handler:^(UIAlertAction * __unused action) {
             
-            NSURL *fileURL = [NSURL fileURLWithPath:[[appDelegate resourceBundle] pathForResource:@"Intro" ofType:@"mp4"]];
+            NSURL *fileURL = [NSURL fileURLWithPath:[appDelegate pathForResource:@"Intro" ofType:@"mp4"]];
             APCIntroVideoViewController *introVideoViewController = [[APCIntroVideoViewController alloc] initWithContentURL:fileURL];
             
             UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:introVideoViewController];

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -1344,7 +1344,8 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 
 - (void)setupDataFromJSONFile:(NSString *)jsonFileName
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:jsonFileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;
@@ -1619,8 +1620,9 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 
 - (void)showPrivacyPolicy
 {
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
     APCWebViewController *webViewController = [[UIStoryboard storyboardWithName:@"APCOnboarding" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWebViewController"];
-    NSString *filePath = [[NSBundle mainBundle] pathForResource: @"PrivacyPolicy" ofType:@"html"];
+    NSString *filePath = [resourceBundle pathForResource: @"PrivacyPolicy" ofType:@"html"];
     NSURL *targetURL = [NSURL URLWithString:filePath];
     NSURLRequest *request = [NSURLRequest requestWithURL:targetURL];
     webViewController.title = NSLocalizedStringWithDefaultValue(@"Privacy Policy", @"APCAppCore", APCBundle(), @"Privacy Policy", @"");
@@ -1652,7 +1654,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         UIAlertAction *pdfAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"View PDF", @"APCAppCore", APCBundle(), @"View PDF", @"View PDF") style:UIAlertActionStyleDefault handler:^(UIAlertAction * __unused action) {
             
             APCWebViewController *webViewController = [[UIStoryboard storyboardWithName:@"APCOnboarding" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWebViewController"];
-            NSString *filePath = [[NSBundle mainBundle] pathForResource:@"consent" ofType:@"pdf"];
+            NSString *filePath = [[appDelegate resourceBundle] pathForResource:@"consent" ofType:@"pdf"];
             NSData *data = [NSData dataWithContentsOfFile:filePath];
             [webViewController.webView setDataDetectorTypes:UIDataDetectorTypeAll];
             webViewController.title = NSLocalizedStringWithDefaultValue(@"Consent", @"APCAppCore", APCBundle(), @"Consent", @"Consent");
@@ -1669,7 +1671,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     if ([consentReviewActions containsObject:kReviewConsentActionVideo]) {
         UIAlertAction *videoAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"Watch Video", @"APCAppCore", APCBundle(), @"Watch Video", @"Watch Video") style:UIAlertActionStyleDefault handler:^(UIAlertAction * __unused action) {
             
-            NSURL *fileURL = [NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:@"Intro" ofType:@"mp4"]];
+            NSURL *fileURL = [NSURL fileURLWithPath:[[appDelegate resourceBundle] pathForResource:@"Intro" ofType:@"mp4"]];
             APCIntroVideoViewController *introVideoViewController = [[APCIntroVideoViewController alloc] initWithContentURL:fileURL];
             
             UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:introVideoViewController];

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
@@ -102,8 +102,7 @@ static NSString * const kSharingOptionsTableViewCellIdentifier = @"SharingOption
 
 - (void)setupDataFromJSON:(NSString *)jsonFileName
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSharingOptionsViewController.m
@@ -102,7 +102,8 @@ static NSString * const kSharingOptionsTableViewCellIdentifier = @"SharingOption
 
 - (void)setupDataFromJSON:(NSString *)jsonFileName
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:jsonFileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -173,7 +173,8 @@
 
 - (NSArray *)surveyFromJSONFile:(NSString *)jsonFileName
 {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:jsonFileName ofType:@"json"];
+    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
+    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -173,8 +173,7 @@
 
 - (NSArray *)surveyFromJSONFile:(NSString *)jsonFileName
 {
-    NSBundle *resourceBundle = [[APCAppDelegate sharedAppDelegate] resourceBundle];
-    NSString *filePath = [resourceBundle pathForResource:jsonFileName ofType:@"json"];
+    NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:jsonFileName ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     
     NSError *parseError;

--- a/APCAppCore/APCAppCoreTests/ORKOrderedTask+APCHelperTests.m
+++ b/APCAppCore/APCAppCoreTests/ORKOrderedTask+APCHelperTests.m
@@ -149,7 +149,7 @@
     NSUInteger leftCount = 0;
     NSUInteger rightCount = 0;
     NSUInteger totalCount = 100;
-    NSUInteger threshold = 45;
+    NSUInteger threshold = 35;
     
     for (int ii=0; ii<totalCount; ii++)
     {


### PR DESCRIPTION
It's really more of a code rearranging and should be reverse compatible to the prior rev of our AppCore branch.
1. Added a method on APCAppDelegate to override the pointer for the resourceBundle. By default, it points at the mainBundle, but apps that inherit the app delegate off of APCAppDelegate can override this.
2. Added a method to override the default tabs in the tab view controller.
