### PR TITLE
Make some AppCore stuff public

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 		5B0601C31AE79AE0009D6D65 /* APCFeedParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B0601C11AE79AE0009D6D65 /* APCFeedParser.m */; };
 		5B0601CD1AE79B50009D6D65 /* APCFeedTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B0601CB1AE79B50009D6D65 /* APCFeedTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5B0601CE1AE79B50009D6D65 /* APCFeedTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B0601CC1AE79B50009D6D65 /* APCFeedTableViewCell.m */; };
-		5B09ED1F1ABC1BEF003C5061 /* APCLicenseInfoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B09ED1D1ABC1BEF003C5061 /* APCLicenseInfoViewController.h */; };
+		5B09ED1F1ABC1BEF003C5061 /* APCLicenseInfoViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B09ED1D1ABC1BEF003C5061 /* APCLicenseInfoViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5B09ED201ABC1BEF003C5061 /* APCLicenseInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B09ED1E1ABC1BEF003C5061 /* APCLicenseInfoViewController.m */; };
 		5B234E141A329BF300A5A3A0 /* APCWithdrawDescriptionViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B234E121A329BF300A5A3A0 /* APCWithdrawDescriptionViewController.h */; };
 		5B234E151A329BF300A5A3A0 /* APCWithdrawDescriptionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B234E131A329BF300A5A3A0 /* APCWithdrawDescriptionViewController.m */; };
@@ -3073,6 +3073,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B09ED1F1ABC1BEF003C5061 /* APCLicenseInfoViewController.h in Headers */,
 				CFFDED731A95731F00B25581 /* APCMedicationTrackerCalendarWeeklyView.h in Headers */,
 				F5F12AF01A2F78490015982C /* APCDashboardProgressTableViewCell.h in Headers */,
 				08EA2AB31A7AD564007549C0 /* UIImage+ImageEffects.h in Headers */,
@@ -3157,7 +3158,6 @@
 				6C6AA27F1B4E056C0056AD47 /* APCDataEncryptor.h in Headers */,
 				5B534ED41B2179550049C6AB /* APCNewsFeedManager.h in Headers */,
 				F5F12AE41A2F78490015982C /* APCTintedTableViewCell.h in Headers */,
-				5B09ED1F1ABC1BEF003C5061 /* APCLicenseInfoViewController.h in Headers */,
 				7BCF70321ACB6C5C00838717 /* APCPassiveDataCollector.h in Headers */,
 				F5B948001A73272C0034C522 /* APCDayOfMonthSelector.h in Headers */,
 				F5F12AEE1A2F78490015982C /* APCDashboardPieGraphTableViewCell.h in Headers */,

--- a/APCAppCore/APCAppCore/APCAppCore.h
+++ b/APCAppCore/APCAppCore/APCAppCore.h
@@ -175,6 +175,7 @@ FOUNDATION_EXPORT const unsigned char APCAppCoreVersionString[];
 #import <APCAppCore/APCWithdrawSurveyViewController.h>
 #import <APCAppCore/APCWithdrawCompleteViewController.h>
 #import <APCAppCore/APCSharingOptionsViewController.h>
+#import <APCAppCore/APCLicenseInfoViewController.h>
 
 /* -------------------------
  Medication Tracking Setup Controllers

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
@@ -59,6 +59,10 @@
 
 @property (weak, nonatomic) IBOutlet UIButton *signOutButton;
 
+@property (weak, nonatomic) IBOutlet UILabel *applicationNameLabel;
+
+@property (weak, nonatomic) IBOutlet UILabel *participationLabel;
+
 @property (weak, nonatomic) IBOutlet UIButton *leaveStudyButton;
 
 @property (weak, nonatomic) IBOutlet UIButton *pauseResumeStudyButton;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -89,10 +89,6 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *studyLabelCenterYConstraint;
 @property (strong, nonatomic) APCPermissionsManager *permissionManager;
 
-@property (weak, nonatomic) IBOutlet UILabel *applicationNameLabel;
-
-@property (weak, nonatomic) IBOutlet UILabel *participationLabel;
-
 @property (strong, nonatomic) APCDemographicUploader  *demographicUploader;
 @property (nonatomic, assign) BOOL                    profileEditsWerePerformed;
 


### PR DESCRIPTION
Move some Profile labels to .h to make them easier to access
Move APCLicenseInfoViewController.h to public so it will be visible outside the project
