### PR TITLE
BRIDGE-1063 Added beginnings of data groups handling to Profile and Signup

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -724,6 +724,9 @@
 		FF94698C1C1A2F0900CF7075 /* APCScheduleExpressionPointSelectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5F129DC1A2F78490015982C /* APCScheduleExpressionPointSelectorTests.m */; };
 		FF94698D1C1A2F0900CF7075 /* APCScheduleExpressionRealLifeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36E06F1B1A33F071005D6EB0 /* APCScheduleExpressionRealLifeTests.m */; };
 		FF94698E1C1A2F0D00CF7075 /* NSDateComponentsHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 360C63D01A339746002EC86C /* NSDateComponentsHelperTests.m */; };
+		FFB892221C4617BB00CD0081 /* APCDataGroupsManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB892201C4617BB00CD0081 /* APCDataGroupsManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FFB892231C4617BB00CD0081 /* APCDataGroupsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB892211C4617BB00CD0081 /* APCDataGroupsManager.m */; };
+		FFB892251C46194E00CD0081 /* APCDataGroupsManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB892241C46194E00CD0081 /* APCDataGroupsManagerTests.m */; };
 		FFF698DD1C18B9E200DC56CC /* ORKOrderedTask+APCHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF698DB1C18B9E200DC56CC /* ORKOrderedTask+APCHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FFF698DE1C18B9E200DC56CC /* ORKOrderedTask+APCHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FFF698DC1C18B9E200DC56CC /* ORKOrderedTask+APCHelper.m */; };
 		FFFA23A91C20A4D800727DA8 /* FilenameTranslation_test.json in Resources */ = {isa = PBXBuildFile; fileRef = FFFA23A81C20A4D800727DA8 /* FilenameTranslation_test.json */; };
@@ -1467,6 +1470,9 @@
 		FF44E50C1C1B585900F07DA9 /* APCTaskResultArchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCTaskResultArchiver.m; sourceTree = "<group>"; };
 		FF44E51A1C1B94A700F07DA9 /* APCTaskResultArchiverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCTaskResultArchiverTests.m; sourceTree = "<group>"; };
 		FF9469831C1A294E00CF7075 /* ORKOrderedTask+APCHelperTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ORKOrderedTask+APCHelperTests.m"; sourceTree = "<group>"; };
+		FFB892201C4617BB00CD0081 /* APCDataGroupsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCDataGroupsManager.h; sourceTree = "<group>"; };
+		FFB892211C4617BB00CD0081 /* APCDataGroupsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCDataGroupsManager.m; sourceTree = "<group>"; };
+		FFB892241C46194E00CD0081 /* APCDataGroupsManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCDataGroupsManagerTests.m; sourceTree = "<group>"; };
 		FFF698DB1C18B9E200DC56CC /* ORKOrderedTask+APCHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ORKOrderedTask+APCHelper.h"; sourceTree = "<group>"; };
 		FFF698DC1C18B9E200DC56CC /* ORKOrderedTask+APCHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ORKOrderedTask+APCHelper.m"; sourceTree = "<group>"; };
 		FFFA23A81C20A4D800727DA8 /* FilenameTranslation_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = FilenameTranslation_test.json; sourceTree = "<group>"; };
@@ -2691,6 +2697,8 @@
 		F5F1293C1A2F78490015982C /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				FFB892201C4617BB00CD0081 /* APCDataGroupsManager.h */,
+				FFB892211C4617BB00CD0081 /* APCDataGroupsManager.m */,
 				EE64F42F1B02517000A402A7 /* APCOnboardingManager.h */,
 				EE64F4301B02517000A402A7 /* APCOnboardingManager.m */,
 				F5F1293D1A2F78490015982C /* APCOnboarding.h */,
@@ -3028,6 +3036,7 @@
 			children = (
 				FFFA23A71C20A49700727DA8 /* test files */,
 				F5F129E01A2F78490015982C /* Info.plist */,
+				FFB892241C46194E00CD0081 /* APCDataGroupsManagerTests.m */,
 				FF9469821C1A28E800CF7075 /* ActivityTests */,
 				36EE894F1A2FEFD700AEA9E6 /* APCScheduleExpressionTests */,
 				360C63CF1A33971B002EC86C /* NSDateComponents+HelperTests */,
@@ -3102,6 +3111,7 @@
 				F5F129EE1A2F78490015982C /* APCDBStatus+AddOn.h in Headers */,
 				F5B947E91A73272C0034C522 /* APCTasksReminderManager.h in Headers */,
 				F5B947C51A73272C0034C522 /* NSManagedObject+APCHelper.h in Headers */,
+				FFB892221C4617BB00CD0081 /* APCDataGroupsManager.h in Headers */,
 				5B9B36AF1A95DEEB00389F42 /* APCActivitiesSectionHeaderView.h in Headers */,
 				F5F12AC71A2F78490015982C /* APCChangePasscodeViewController.h in Headers */,
 				6C6AA2811B4E056C0056AD47 /* APCDataUploader.h in Headers */,
@@ -3625,6 +3635,7 @@
 				5B534ED51B2179550049C6AB /* APCNewsFeedManager.m in Sources */,
 				7B558D291AE587DF00129167 /* CLLocation+APCAdditions.m in Sources */,
 				5BD6EBA31A9A46BB00C3BFB0 /* APCStudyLandingCollectionViewCell.m in Sources */,
+				FFB892231C4617BB00CD0081 /* APCDataGroupsManager.m in Sources */,
 				F5F12A111A2F78490015982C /* APCUser.m in Sources */,
 				F5F12B0B1A2F78490015982C /* APCPasscodeView.m in Sources */,
 				F5B946271A7309A20034C522 /* ZZArchiveEntry.m in Sources */,
@@ -3891,6 +3902,7 @@
 				0833AE1E1A76C016001D8AA0 /* (null) in Sources */,
 				FF94698B1C1A2F0900CF7075 /* APCScheduleExpressionParserTests.m in Sources */,
 				FF94698D1C1A2F0900CF7075 /* APCScheduleExpressionRealLifeTests.m in Sources */,
+				FFB892251C46194E00CD0081 /* APCDataGroupsManagerTests.m in Sources */,
 				FF94698C1C1A2F0900CF7075 /* APCScheduleExpressionPointSelectorTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/APCAppCore/APCAppCore/APCAppCore.h
+++ b/APCAppCore/APCAppCore/APCAppCore.h
@@ -49,6 +49,7 @@ FOUNDATION_EXPORT const unsigned char APCAppCoreVersionString[];
 #import <APCAppCore/APCCMSSupport.h>
 #import <APCAppCore/APCConstants.h>
 #import <APCAppCore/APCAppDelegate.h>
+#import <APCAppCore/APCDataGroupsManager.h>
 #import <APCAppCore/APCDataMonitor.h>
 #import <APCAppCore/APCDataMonitor+Bridge.h>
 #import <APCAppCore/APCDataSubstrate.h>

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.h
@@ -40,6 +40,7 @@
 - (void) signUpWithDataGroups:(NSArray<NSString *> *)dataGroups onCompletion:(void (^)(NSError *))completionBlock;
 - (void) signInOnCompletion:(void (^)(NSError * error))completionBlock;
 - (void) signOutOnCompletion:(void (^)(NSError * error))completionBlock;
+- (void) updateDataGroups:(NSArray<NSString *> *)dataGroups onCompletion:(void (^)(NSError * error))completionBlock;
 - (void) updateProfileOnCompletion:(void (^)(NSError * error))completionBlock;
 - (void) updateCustomProfile:(SBBUserProfile*)profile onCompletion:(void (^)(NSError * error))completionBlock;
 - (void) getProfileOnCompletion:(void (^)(NSError *error))completionBlock;

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.m
@@ -47,7 +47,7 @@
 
 - (void)signUpOnCompletion:(void (^)(NSError *))completionBlock
 {
-    [self signUpWithDataGroups:nil onCompletion:completionBlock];
+    [self signUpWithDataGroups:self.dataGroups onCompletion:completionBlock];
 }
 
 - (void)signUpWithDataGroups:(NSArray<NSString *> *)dataGroups onCompletion:(void (^)(NSError *))completionBlock

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.h
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.h
@@ -74,6 +74,16 @@
 - (id)initWithReference: (NSString *)reference task:(APCTask *)task;
 
 /**
+ Designated Initializer
+ 
+ @param     reference           Reference for the archive used as a directory name in temp directory
+ @param     schemaRevision      Schema revision associated with this task
+ 
+ @return    APCDataArchive      An instance of APCDataArchive
+ */
+- (id)initWithReference: (NSString *)reference schemaRevision:(NSNumber *)schemaRevision;
+
+/**
  Inserts json data into the archive.
  
  @param     jsonData            JSON data to be inserted into the zip archive.

--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCDataArchive.m
@@ -63,6 +63,7 @@ static NSString * kJsonInfoFilename                 = @"info.json";
 
 @property (nonatomic, strong) NSString *reference;
 @property (nonatomic, strong) APCTask *task;
+@property (nonatomic, strong) NSNumber *schemaRevision;
 @property (nonatomic, strong) ZZArchive *zipArchive;
 @property (nonatomic, strong) NSMutableArray *zipEntries;
 @property (nonatomic, strong) NSMutableArray *filesList;
@@ -91,6 +92,19 @@ static NSString * kJsonInfoFilename                 = @"info.json";
     if (self) {
         _reference = reference;
         _task = task;
+        _schemaRevision = task.taskSchemaRevision;
+        [self createArchive];
+    }
+    
+    return self;
+}
+
+- (id)initWithReference: (NSString *)reference schemaRevision:(NSNumber *)schemaRevision
+{
+    self = [super init];
+    if (self) {
+        _reference = reference;
+        _schemaRevision = schemaRevision;
         [self createArchive];
     }
     
@@ -204,8 +218,8 @@ static NSString * kJsonInfoFilename                 = @"info.json";
         [self.infoDict setObject:[APCUtilities phoneInfo] forKey:kPhoneInfoKey];
         [self.infoDict setObject:[NSUUID new].UUIDString forKey:kTaskRunKey];
         [self.infoDict setObject:self.reference forKey:kItemKey];
-        if (self.task.taskSchemaRevision) {
-            [self.infoDict setObject:self.task.taskSchemaRevision forKey:kSchemaRevisionKey];
+        if (self.schemaRevision) {
+            [self.infoDict setObject:self.schemaRevision forKey:kSchemaRevisionKey];
         }
         if ([self.task.taskType isEqualToNumber:@(APCTaskTypeSurveyTask)]) {
             // Survey schema is better matched by created date and survey guid

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
@@ -49,7 +49,7 @@ extern NSString *const kActivitiesStoryBoardKey;
 extern NSString *const kHealthProfileStoryBoardKey;
 extern NSString *const kNewsFeedStoryBoardKey;
 
-@class APCDataSubstrate, APCDataMonitor, APCScheduler, APCPasscodeViewController, APCTasksReminderManager, APCPassiveDataCollector, APCFitnessAllocation;
+@class APCDataSubstrate, APCDataMonitor, APCScheduler, APCPasscodeViewController, APCTasksReminderManager, APCPassiveDataCollector, APCFitnessAllocation, APCDataGroupsManager;
 
 @interface APCAppDelegate : UIResponder <UIApplicationDelegate, APCOnboardingManagerProvider, APCPasscodeViewControllerDelegate, SBBBridgeAppDelegate>
 
@@ -136,7 +136,6 @@ extern NSString *const kNewsFeedStoryBoardKey;
 - (NSDate*)applicationBecameActiveDate;
 
 - (void)updateNewsFeedBadgeCount;
-
 
 // List of the tabs to use to setup the tabbar
 - (NSMutableArray <APCScene *> *)tabBarScenes;

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -1004,6 +1004,9 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
 }
 
 - (APCDataGroupsManager *)dataGroupsManagerForUser:(APCUser*)user {
+    if (user == nil) {
+        user = self.dataSubstrate.currentUser;
+    }
     return [[APCDataGroupsManager alloc] initWithDataGroups:user.dataGroups mapping:nil];
 }
 

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -1003,6 +1003,10 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     return _onboardingManager;
 }
 
+- (APCDataGroupsManager *)dataGroupsManagerForUser:(APCUser*)user {
+    return [[APCDataGroupsManager alloc] initWithDataGroups:user.dataGroups mapping:nil];
+}
+
 - (APCPermissionsManager *)permissionsManager {
     return [APCPermissionsManager new];
 }

--- a/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
@@ -1,0 +1,30 @@
+//
+//  APCDataGroupsManager.h
+//  APCAppCore
+//
+//  Created by Shannon Young on 1/12/16.
+//  Copyright © 2016 Apple, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class APCUser, APCTableViewRow;
+
+@interface APCDataGroupsManager : NSObject
+
+@property (nonatomic, readonly) BOOL hasChanges;
+@property (nonatomic, readonly) NSArray * _Nullable dataGroups;
+@property (nonatomic, readonly) NSDictionary * _Nullable mapping;
+
+- (instancetype)initWithDataGroups:(NSArray * _Nullable)dataGroups mapping:(NSDictionary * _Nullable)mapping;
+
+- (BOOL)needsUserInfoDataGroups;
+- (BOOL)isStudyControlGroup;
+- (NSArray <APCTableViewRow *> * _Nullable)surveyItems;
+- (void)setSurveyAnswerWithIdentifier:(NSString*)identifier selectedIndices:(NSArray*)selectedIndices;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class APCUser, APCTableViewRow;
+@class APCUser, APCTableViewRow, APCTableViewItem;
 
 @interface APCDataGroupsManager : NSObject
 
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isStudyControlGroup;
 - (NSArray <APCTableViewRow *> * _Nullable)surveyItems;
 - (void)setSurveyAnswerWithIdentifier:(NSString*)identifier selectedIndices:(NSArray*)selectedIndices;
+- (void)setSurveyAnswerWithItem:(APCTableViewItem*)item;
 
 @end
 

--- a/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
@@ -61,7 +61,7 @@ extern NSString * const APCDataGroupsStepIdentifier;
 - (BOOL)isStudyControlGroup;
 
 - (NSArray <APCTableViewRow *> * _Nullable)surveyItems;
-- (ORKFormStep *)surveyStep;
+- (ORKFormStep * _Nullable)surveyStep;
 
 - (void)setSurveyAnswerWithItem:(APCTableViewItem*)item;
 - (void)setSurveyAnswerWithStepResult:(ORKStepResult *)result;

--- a/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
@@ -7,10 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <ResearchKit/ResearchKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class APCUser, APCTableViewRow, APCTableViewItem;
+
+extern NSString * const APCDataGroupsStepIdentifier;
 
 @interface APCDataGroupsManager : NSObject
 
@@ -22,9 +25,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)needsUserInfoDataGroups;
 - (BOOL)isStudyControlGroup;
+
 - (NSArray <APCTableViewRow *> * _Nullable)surveyItems;
-- (void)setSurveyAnswerWithIdentifier:(NSString*)identifier selectedIndices:(NSArray*)selectedIndices;
+- (ORKFormStep *)surveyStep;
+
 - (void)setSurveyAnswerWithItem:(APCTableViewItem*)item;
+- (void)setSurveyAnswerWithStepResult:(ORKStepResult *)result;
+- (void)setSurveyAnswerWithIdentifier:(NSString*)identifier selectedIndices:(NSArray*)selectedIndices;
+
 
 @end
 

--- a/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.h
@@ -2,8 +2,33 @@
 //  APCDataGroupsManager.h
 //  APCAppCore
 //
-//  Created by Shannon Young on 1/12/16.
-//  Copyright © 2016 Apple, Inc. All rights reserved.
+// Copyright (c) 2015, Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 #import <Foundation/Foundation.h>
@@ -15,6 +40,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString * const APCDataGroupsStepIdentifier;
 
+/**
+ *  Manager to configure and handle setting and updating of the data groups during onboarding and from the profile.
+ *
+ *  This superclass returns information about the data groups used by this app. The generic version included in AppCore
+ *  uses a dictionary to define the data groups, which group (if any) is the "control" group, and to allow updating of
+ *  data groups via either a survey result (onboarding) or a tableViewItem (profile). This manager does *not* include a 
+ *  pointer to the user and is intended as a temporary object for managing state during onboarding or while viewing or 
+ *  editing the user's profile.
+ */
 @interface APCDataGroupsManager : NSObject
 
 @property (nonatomic, readonly) BOOL hasChanges;

--- a/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.m
@@ -1,0 +1,183 @@
+//
+//  APCDataGroupsManager.m
+//  APCAppCore
+//
+//  Created by Shannon Young on 1/12/16.
+//  Copyright © 2016 Apple, Inc. All rights reserved.
+//
+
+#import "APCDataGroupsManager.h"
+#import "APCAppCore.h"
+
+NSString * const APCDataGroupsMappingItemsKey = @"items";
+NSString * const APCDataGroupsMappingRequiredKey = @"required";
+NSString * const APCDataGroupsMappingQuestionsKey = @"questions";
+
+NSString * const APCDataGroupsMappingSurveyQuestionIdentifierKey = @"identifier";
+NSString * const APCDataGroupsMappingSurveyQuestionTypeKey = @"type";
+NSString * const APCDataGroupsMappingSurveyQuestionPromptKey = @"prompt";
+NSString * const APCDataGroupsMappingSurveyQuestionValueMapKey = @"valueMap";
+NSString * const APCDataGroupsMappingSurveyQuestionTypeBoolean = @"boolean";
+NSString * const APCDataGroupsMappingSurveyQuestionValueMapValueKey = @"value";
+NSString * const APCDataGroupsMappingSurveyQuestionValueMapGroupsKey = @"groups";
+
+@interface APCDataGroupsManager ()
+
+@property (nonatomic, copy) NSSet *originalDataGroupsSet;
+@property (nonatomic, strong) NSMutableSet *dataGroupsSet;
+
+@end
+
+@implementation APCDataGroupsManager
+
++ (NSString*)pathForDataGroupsMapping {
+    return [[APCAppDelegate sharedAppDelegate] pathForResource:@"DataGroupsMapping" ofType:@"json"];
+}
+
++ (NSDictionary*)defaultMapping {
+    static NSDictionary * _dataGroupMapping;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSString *path = [self pathForDataGroupsMapping];
+        NSData *json = [NSData dataWithContentsOfFile:path];
+        if (json) {
+            NSError *parseError;
+            _dataGroupMapping = [NSJSONSerialization JSONObjectWithData:json options:NSJSONReadingMutableContainers error:&parseError];
+            if (parseError) {
+                NSLog(@"Error parsing data group mapping: %@", parseError);
+            }
+        }
+        
+    });
+    return _dataGroupMapping;
+}
+
+- (instancetype)initWithDataGroups:(NSArray *)dataGroups mapping:(NSDictionary*)mapping {
+    self = [super init];
+    if (self) {
+        _mapping = [mapping copy] ?: [[self class] defaultMapping];
+        _originalDataGroupsSet = (dataGroups.count > 0) ? [NSSet setWithArray:dataGroups] : [NSSet new];
+        _dataGroupsSet = (dataGroups.count > 0) ? [NSMutableSet setWithArray:dataGroups] : [NSMutableSet new];
+    }
+    return self;
+}
+
+- (NSArray *)dataGroups {
+    return [self.dataGroupsSet allObjects];
+}
+
+- (BOOL)hasChanges {
+    return ![self.dataGroupsSet isEqualToSet:self.originalDataGroupsSet];
+}
+
+- (BOOL)needsUserInfoDataGroups {
+    if ([self.mapping[APCDataGroupsMappingRequiredKey] boolValue]) {
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"group_name IN %@", self.dataGroups];
+        return [[self fiteredDataGroupsUsingPredicate:predicate] count] == 0;
+    }
+    return NO;
+}
+
+- (BOOL)isStudyControlGroup {
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"(group_name IN %@) AND (is_control_group = YES)", self.dataGroups];
+    return [[self fiteredDataGroupsUsingPredicate:predicate] count] > 0;
+}
+
+- (NSArray <NSString *> * _Nullable)fiteredDataGroupsUsingPredicate:(NSPredicate *)predicate {
+    return [self.mapping[APCDataGroupsMappingItemsKey] filteredArrayUsingPredicate:predicate];
+}
+
+- (NSArray <APCTableViewRow *> * _Nullable)surveyItems {
+    
+    NSArray *questions = self.mapping[APCDataGroupsMappingQuestionsKey];
+    if (questions.count == 0) {
+        return nil;
+    }
+
+    NSMutableArray *result = [NSMutableArray new];
+    for (NSDictionary *question in questions) {
+        NSString *questionType = question[APCDataGroupsMappingSurveyQuestionTypeKey];
+        if ([questionType isEqualToString:APCDataGroupsMappingSurveyQuestionTypeBoolean])
+        {
+            APCTableViewCustomPickerItem *item = [[APCTableViewCustomPickerItem alloc] init];
+            item.identifier = question[APCDataGroupsMappingSurveyQuestionIdentifierKey];
+            item.caption = question[APCDataGroupsMappingSurveyQuestionPromptKey];
+            item.textAlignnment = NSTextAlignmentRight;
+            
+            // Set the values to YES or NO
+            NSArray *valueMap = question[APCDataGroupsMappingSurveyQuestionValueMapKey];
+            NSString *yes = NSLocalizedStringWithDefaultValue(@"YES", @"APCAppCore", APCBundle(), @"Yes", @"Yes");
+            NSString *no = NSLocalizedStringWithDefaultValue(@"NO", @"APCAppCore", APCBundle(), @"No", @"No");
+            if ([valueMap[0][APCDataGroupsMappingSurveyQuestionValueMapValueKey] boolValue]) {
+                item.pickerData = @[yes, no];
+            }
+            else {
+                item.pickerData = @[no, yes];
+            }
+            
+            // Set selected rows
+            NSString *selectedValue = [[self selectedValuesForMap:valueMap] firstObject];
+            if (selectedValue != nil) {
+                item.selectedRowIndices = [selectedValue boolValue] ? @[@0] : @[@1];
+            }
+            
+            APCTableViewRow *row = [APCTableViewRow new];
+            row.item = item;
+            row.itemType = kAPCUserInfoItemTypeDataGroups;
+            [result addObject:row];
+        }
+        else
+        {
+            NSAssert1(NO, @"Data groups survey question of type %@ is not handled.", questionType);
+        }
+    }
+    
+    return [result copy];
+}
+
+- (NSArray *)selectedValuesForMap:(NSArray*)valueMap {
+    
+    if (self.dataGroups.count == 0) {
+        return nil;
+    }
+    
+    NSMutableArray *values = [NSMutableArray new];
+    NSSet *groupSet = [NSSet setWithArray:self.dataGroups];
+    for (NSDictionary *map in valueMap) {
+        NSMutableSet *mapSet = [NSMutableSet setWithArray:map[APCDataGroupsMappingSurveyQuestionValueMapGroupsKey]];
+        [mapSet intersectSet:groupSet];
+        if (mapSet.count > 0) {
+            [values addObject:map[APCDataGroupsMappingSurveyQuestionValueMapValueKey]];
+        }
+    }
+    
+    return values;
+}
+
+- (void)setSurveyAnswerWithIdentifier:(NSString*)identifier selectedIndices:(NSArray*)selectedIndices {
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@", APCDataGroupsMappingSurveyQuestionIdentifierKey, identifier];
+    NSDictionary *question = [[self.mapping[APCDataGroupsMappingQuestionsKey] filteredArrayUsingPredicate:predicate] firstObject];
+    
+    // Get all the groups that are defined by this question
+    NSArray *groupsMap = [question[APCDataGroupsMappingSurveyQuestionValueMapKey] valueForKey:APCDataGroupsMappingSurveyQuestionValueMapGroupsKey];
+    
+    NSMutableSet *excludeSet = [NSMutableSet new];
+    NSMutableSet *includeSet = [NSMutableSet new];
+    for (NSUInteger idx = 0; idx < groupsMap.count; idx++) {
+        if ([selectedIndices containsObject:@(idx)]) {
+            [includeSet addObjectsFromArray:groupsMap[idx]];
+        }
+        else {
+            [excludeSet addObjectsFromArray:groupsMap[idx]];
+        }
+    }
+    
+    // Remove data groups that are *not* in the selected indices
+    [self.dataGroupsSet minusSet:excludeSet];
+    
+    // Union data groups that *are* in the selected indices
+    [self.dataGroupsSet unionSet:includeSet];
+}
+
+@end

--- a/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCDataGroupsManager.m
@@ -2,8 +2,33 @@
 //  APCDataGroupsManager.m
 //  APCAppCore
 //
-//  Created by Shannon Young on 1/12/16.
-//  Copyright © 2016 Apple, Inc. All rights reserved.
+// Copyright (c) 2015, Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 #import "APCDataGroupsManager.h"
@@ -219,11 +244,12 @@ NSString * const APCDataGroupsMappingSurveyQuestionValueMapGroupsKey = @"groups"
             NSDictionary *question = [self questionWithIndentifier:choiceResult.identifier];
             NSArray *valueMap = question[APCDataGroupsMappingSurveyQuestionValueMapKey];
             
-            // Get the groups that are to be included
+            // Get the groups that are to be included based on the answer to this question
             NSPredicate *includePredicate = [NSPredicate predicateWithFormat:@"%K IN %@", APCDataGroupsMappingSurveyQuestionValueMapValueKey, choiceResult.choiceAnswers];
             NSArray *includeGroups = [[valueMap filteredArrayUsingPredicate:includePredicate] valueForKey:APCDataGroupsMappingSurveyQuestionValueMapGroupsKey];
             
-            // Get the groups that are changing to be excluded
+            // Get the groups that are changing to be excluded (which are the groups mapped to
+            // an aswer that was *not* selected
             NSPredicate *excludePredicate = [NSCompoundPredicate notPredicateWithSubpredicate:includePredicate];
             NSArray *excludeGroups = [[valueMap filteredArrayUsingPredicate:excludePredicate] valueForKey:APCDataGroupsMappingSurveyQuestionValueMapGroupsKey];
             
@@ -232,7 +258,7 @@ NSString * const APCDataGroupsMappingSurveyQuestionValueMapGroupsKey = @"groups"
                 [self.dataGroupsSet minusSet:[NSSet setWithArray:groups]];
             }
             
-            // Union data groups that *are* in the selected subset
+            // Add data groups that *are* in the selected subset
             for (NSArray *groups in includeGroups) {
                 [self.dataGroupsSet unionSet:[NSSet setWithArray:groups]];
             }
@@ -274,7 +300,8 @@ NSString * const APCDataGroupsMappingSurveyQuestionValueMapGroupsKey = @"groups"
         }
     }
     
-    // Remove data groups that are *not* in the selected indices
+    // Remove data groups that are *not* in the selected indices (and are instead associated
+    // with a choice that was *not* selected)
     [self.dataGroupsSet minusSet:excludeSet];
     
     // Union data groups that *are* in the selected indices

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboarding.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboarding.h
@@ -66,6 +66,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isSignInSupported;
 
+- (BOOL)hasNextStep:(ORKStep *)step;
+- (BOOL)hasPreviousStep:(ORKStep *)step;
+
 @end
 
 
@@ -77,6 +80,18 @@ NS_ASSUME_NONNULL_BEGIN
  *  Return the scene for the desired type, or nil if the scene should be skipped.
  */
 - (nullable APCScene *)onboarding:(APCOnboarding *)onboarding sceneOfType:(NSString *)type;
+
+@optional
+
+/**
+ * Called whenever the step result changes for a given step
+ */
+- (void)onboarding:(APCOnboarding *)onboarding didFinishStepWithResult:(ORKStepResult*)stepResult;
+
+/**
+ * Called when finished
+ */
+- (void)onboardingDidFinish;
 
 @end
 

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboarding.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboarding.m
@@ -38,9 +38,9 @@
 #import "APCScene.h"
 
 
-@interface APCOnboarding ()
+@interface APCOnboarding () <ORKStepViewControllerDelegate>
 
-@property (nonatomic, strong) NSMutableDictionary *__nullable scenes;
+@property (nonatomic, strong) NSMutableDictionary <NSString*, APCScene *> * __nullable scenes;
 
 @property (nonatomic, readwrite) APCOnboardingTask *onboardingTask;
 
@@ -81,83 +81,66 @@
 - (NSDictionary *)prepareScenes {
     NSMutableDictionary *scenes = [NSMutableDictionary new];
     
-    APCScene *signUp = [self.delegate onboarding:self sceneOfType:kAPCSignUpInclusionCriteriaStepIdentifier];
-    if (signUp) {
-        scenes[kAPCSignUpInclusionCriteriaStepIdentifier] = signUp;
-    }
+    BOOL (^addScene)(NSString *) = ^BOOL(NSString * sceneType){
+        APCScene *scene = [self.delegate onboarding:self sceneOfType:sceneType];
+        if (scene) {
+            if (scene.step == nil) {
+                scene.step = [[ORKStep alloc] initWithIdentifier:sceneType];
+            }
+            // Map the scene to both the sceneType and the step identifier in case
+            // they are not the same.
+            scenes[sceneType] = scene;
+            scenes[scene.step.identifier] = scene;
+        }
+        return (scene != nil);
+    };
     
-    APCScene *eligible = [self.delegate onboarding:self sceneOfType:kAPCSignUpEligibleStepIdentifier];
-    if (eligible) {
-        scenes[kAPCSignUpEligibleStepIdentifier] = eligible;
-    }
-    
-    APCScene *ineligible = [self.delegate onboarding:self sceneOfType:kAPCSignUpIneligibleStepIdentifier];
-    if (ineligible) {
-        scenes[kAPCSignUpIneligibleStepIdentifier] = ineligible;
-    }
-    
-    APCScene *permissionPriming = [self.delegate onboarding:self sceneOfType:kAPCSignUpPermissionsPrimingStepIdentifier];
-    if (permissionPriming) {
-        scenes[kAPCSignUpPermissionsPrimingStepIdentifier] = permissionPriming;
-    }
-    
-    APCScene *generalInfo = [self.delegate onboarding:self sceneOfType:kAPCSignUpGeneralInfoStepIdentifier];
-    if (generalInfo) {
-        scenes[kAPCSignUpGeneralInfoStepIdentifier] = generalInfo;
-    }
-    
-    APCScene *medical = [self.delegate onboarding:self sceneOfType:kAPCSignUpMedicalInfoStepIdentifier];
-    if (medical) {
-        scenes[kAPCSignUpMedicalInfoStepIdentifier] = medical;
-    }
-    
-    APCScene *custom = [self.delegate onboarding:self sceneOfType:kAPCSignUpCustomInfoStepIdentifier];
-    if (custom) {
-        self.onboardingTask.customStepIncluded = YES;
-        scenes[kAPCSignUpCustomInfoStepIdentifier] = custom;
-    }
-    
-    APCScene *passcode = [self.delegate onboarding:self sceneOfType:kAPCSignUpPasscodeStepIdentifier];
-    if (passcode) {
-        scenes[kAPCSignUpPasscodeStepIdentifier] = passcode;
-    }
-    
-    APCScene *permissions = [self.delegate onboarding:self sceneOfType:kAPCSignUpPermissionsStepIdentifier];
-    if (permissions) {
-        scenes[kAPCSignUpPermissionsStepIdentifier] = permissions;
-    }
-    
-    APCScene *thankYou = [self.delegate onboarding:self sceneOfType:kAPCSignUpThankYouStepIdentifier];
-    if (thankYou) {
-        scenes[kAPCSignUpThankYouStepIdentifier] = thankYou;
-    }
-    
-    APCScene *signIn = [self.delegate onboarding:self sceneOfType:kAPCSignInStepIdentifier];
-    if (signIn) {
-        scenes[kAPCSignInStepIdentifier] = signIn;
-    }
-    
-    APCScene *shareApp = [self.delegate onboarding:self sceneOfType:kAPCSignUpShareAppStepIdentifier];
-    if (shareApp) {
-        scenes[kAPCSignUpShareAppStepIdentifier] = shareApp;
-    }
+    addScene(kAPCSignUpInclusionCriteriaStepIdentifier);
+    addScene(kAPCSignUpEligibleStepIdentifier);
+    addScene(kAPCSignUpIneligibleStepIdentifier);
+    addScene(kAPCSignUpPermissionsPrimingStepIdentifier);
+    addScene(kAPCSignUpDataGroupsStepIdentifier);
+    addScene(kAPCSignUpGeneralInfoStepIdentifier);
+    addScene(kAPCSignUpMedicalInfoStepIdentifier);
+    self.onboardingTask.customStepIncluded = addScene(kAPCSignUpCustomInfoStepIdentifier);
+    addScene(kAPCSignUpPasscodeStepIdentifier);
+    addScene(kAPCSignUpPermissionsStepIdentifier);
+    addScene(kAPCSignUpThankYouStepIdentifier);
+    addScene(kAPCSignInStepIdentifier);
+    addScene(kAPCSignUpShareAppStepIdentifier);
     
     return scenes;
 }
 
+- (BOOL)hasNextStep:(ORKStep *)step {
+    ORKTaskResult *result = nil;
+    return [self.onboardingTask stepAfterStep:step withResult:result] != nil;
+}
+
+- (BOOL)hasPreviousStep:(ORKStep *)step {
+    ORKTaskResult *result = nil;
+    return [self.onboardingTask stepBeforeStep:step withResult:result] != nil;
+}
+
 - (UIViewController *)nextScene {
     ORKTaskResult *result = nil;
-    self.currentStep = [self.onboardingTask stepAfterStep:self.currentStep withResult:result];
-    
+    ORKStep *nextStep = [self.onboardingTask stepAfterStep:self.currentStep withResult:result];
+
     // If the task asks for a step that we don't have a scene for, we skip the step and move on to the next
-    UIViewController *nextViewController = [self viewControllerForSceneIdentifier:self.currentStep.identifier];
+    UIViewController *nextViewController = [self viewControllerForSceneIdentifier:nextStep.identifier];
+    if ([nextViewController isKindOfClass:[ORKStepViewController class]]) {
+        ((ORKStepViewController*)nextViewController).delegate = self;
+    }
+    
+    self.currentStep = nextStep;
     if (nextViewController) {
         return nextViewController;
     }
-    if (_currentStep) {
+    if (self.currentStep != nil) {
         APCLogDebug(@"No scene for next step \"%@\", skipping", _currentStep.identifier);
         return [self nextScene];
     }
+    
     APCLogDebug(@"Last onboarding scene reached");
     return nil;
 }
@@ -192,39 +175,65 @@
     NSAssert(_scenes, @"Only call this once we have scenes");
     NSAssert(_onboardingTask, @"Need to have an onboarding task before creating steps from scenes");
     
-    if (nil != _scenes[kAPCSignUpInclusionCriteriaStepIdentifier]) {
-        _onboardingTask.inclusionCriteriaStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpInclusionCriteriaStepIdentifier];
+    _onboardingTask.inclusionCriteriaStep = _scenes[kAPCSignUpInclusionCriteriaStepIdentifier].step;
+    _onboardingTask.eligibleStep = _scenes[kAPCSignUpEligibleStepIdentifier].step;
+    _onboardingTask.ineligibleStep = _scenes[kAPCSignUpIneligibleStepIdentifier].step;
+    _onboardingTask.permissionsPrimingStep = _scenes[kAPCSignUpPermissionsPrimingStepIdentifier].step;
+    _onboardingTask.dataGroupsStep = _scenes[kAPCSignUpDataGroupsStepIdentifier].step;
+    _onboardingTask.generalInfoStep = _scenes[kAPCSignUpGeneralInfoStepIdentifier].step;
+    _onboardingTask.medicalInfoStep = _scenes[kAPCSignUpMedicalInfoStepIdentifier].step;
+    _onboardingTask.customInfoStep = _scenes[kAPCSignUpCustomInfoStepIdentifier].step;
+    _onboardingTask.passcodeStep = _scenes[kAPCSignUpPasscodeStepIdentifier].step;
+    _onboardingTask.permissionsStep = _scenes[kAPCSignUpPermissionsStepIdentifier].step;
+    _onboardingTask.thankyouStep = _scenes[kAPCSignUpThankYouStepIdentifier].step;
+    _onboardingTask.signInStep = _scenes[kAPCSignInStepIdentifier].step;
+}
+
+#pragma mark - ORKStepViewControllerDelegate
+
+- (void)stepViewController:(ORKStepViewController * __unused)stepViewController didFinishWithNavigationDirection:(ORKStepViewControllerNavigationDirection)direction {
+    if (direction == ORKStepViewControllerNavigationDirectionForward) {
+        
+        // Let the delegate handle the change
+        if ([self.delegate respondsToSelector:@selector(onboarding:didFinishStepWithResult:)]) {
+            [self.delegate onboarding:self didFinishStepWithResult:stepViewController.result];
+        }
+        
+        UIViewController *nextVC = [self nextScene];
+        if (nextVC) {
+            // go forward
+            [stepViewController.navigationController pushViewController:nextVC animated:YES];
+        }
+        else if ([self.delegate respondsToSelector:@selector(onboardingDidFinish)]) {
+            [self.delegate onboardingDidFinish];
+        }
     }
-    if (nil != _scenes[kAPCSignUpEligibleStepIdentifier]) {
-        _onboardingTask.eligibleStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpEligibleStepIdentifier];
+    else {
+        // go back
+        [stepViewController.navigationController popViewControllerAnimated:YES];
     }
-    if (nil != _scenes[kAPCSignUpIneligibleStepIdentifier]) {
-        _onboardingTask.ineligibleStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpIneligibleStepIdentifier];
-    }
-    if (nil != _scenes[kAPCSignUpPermissionsPrimingStepIdentifier]) {
-        _onboardingTask.permissionsPrimingStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpPermissionsPrimingStepIdentifier];
-    }
-    if (nil != _scenes[kAPCSignUpGeneralInfoStepIdentifier]) {
-        _onboardingTask.generalInfoStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpGeneralInfoStepIdentifier];
-    }
-    if (nil != _scenes[kAPCSignUpMedicalInfoStepIdentifier]) {
-        _onboardingTask.medicalInfoStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpMedicalInfoStepIdentifier];
-    }
-    if (nil != _scenes[kAPCSignUpCustomInfoStepIdentifier]) {
-        _onboardingTask.customInfoStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpCustomInfoStepIdentifier];
-    }
-    if (nil != _scenes[kAPCSignUpPasscodeStepIdentifier]) {
-        _onboardingTask.passcodeStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpPasscodeStepIdentifier];
-    }
-    if (nil != _scenes[kAPCSignUpPermissionsStepIdentifier]) {
-        _onboardingTask.permissionsStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpPermissionsStepIdentifier];
-    }
-    if (nil != _scenes[kAPCSignUpThankYouStepIdentifier]) {
-        _onboardingTask.thankyouStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpThankYouStepIdentifier];
-    }
-    if (nil != _scenes[kAPCSignInStepIdentifier]) {
-        _onboardingTask.signInStep = [[ORKStep alloc] initWithIdentifier:kAPCSignInStepIdentifier];
-    }
+}
+
+- (void)stepViewControllerResultDidChange:(ORKStepViewController * __unused)stepViewController {
+    // Do nothing
+}
+
+- (void)stepViewControllerDidFail:(ORKStepViewController * __unused)stepViewController withError:(nullable NSError * __unused)error {
+    // Do  nothing
+}
+
+- (void)stepViewController:(ORKStepViewController * __unused)stepViewController recorder:(ORKRecorder * __unused)recorder didFailWithError:(NSError * __unused)error {
+    // Do  nothing
+}
+
+- (BOOL)stepViewControllerHasPreviousStep:(ORKStepViewController *  __unused)stepViewController {
+    BOOL ret = [self hasPreviousStep:stepViewController.step];
+    return ret;
+}
+
+- (BOOL)stepViewControllerHasNextStep:(ORKStepViewController *  __unused)stepViewController {
+    BOOL ret =  [self hasNextStep:stepViewController.step];
+    return ret;
 }
 
 @end

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.h
@@ -38,6 +38,7 @@
 
 @class APCOnboardingManager;
 @class APCPermissionsManager;
+@class APCDataGroupsManager;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -51,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (APCOnboardingManager *)onboardingManager;
 /** The permissions manager for the app. */
 - (APCPermissionsManager *)permissionsManager;
+/** The data groups manager for the app. */
+- (APCDataGroupsManager *)dataGroupsManagerForUser:(APCUser*)user;
 @optional
 /**
  *  Kept for backwards compatibility: return the inclusion criteria scene.
@@ -81,6 +84,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// The permissions manager defining and requesting needed permissions.
 @property (strong, nonatomic, readonly) APCPermissionsManager *permissionsManager;
+
+/// The data groups manager defining data groups mapping
+@property (strong, nonatomic, readonly) APCDataGroupsManager *dataGroupsManager;
 
 /// Whether a sign-in action, to resume a study previously enrolled in, is supported. Defaults to YES.
 @property (nonatomic, getter=isSignInSupported) BOOL signInSupported;

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** The permissions manager for the app. */
 - (APCPermissionsManager *)permissionsManager;
 /** The data groups manager for the app. */
-- (APCDataGroupsManager *)dataGroupsManagerForUser:(APCUser*)user;
+- (APCDataGroupsManager *)dataGroupsManagerForUser:(APCUser * _Nullable)user;
 @optional
 /**
  *  Kept for backwards compatibility: return the inclusion criteria scene.

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
@@ -33,6 +33,7 @@
 //
 
 #import "APCOnboardingManager.h"
+#import "APCDataGroupsManager.h"
 #import "APCPermissionsManager.h"
 #import "APCUserInfoConstants.h"
 #import "APCLog.h"
@@ -159,6 +160,13 @@ NSString * const kAPCOnboardingStoryboardName = @"APCOnboarding";
     if ([type isEqualToString:kAPCSignUpPermissionsPrimingStepIdentifier]) {
         return [[APCScene alloc] initWithName:@"APCPermissionPrimingViewController" inStoryboard:kAPCOnboardingStoryboardName];     // "What to Expect" screen
     }
+    if ([type isEqualToString:kAPCSignUpDataGroupsStepIdentifier]) {
+        ORKStep *step = [self.dataGroupsManager surveyStep];
+        if (step != nil) {
+            return [[APCScene alloc] initWithStep:step];
+        }
+        return nil;
+    }
     if ([type isEqualToString:kAPCSignUpGeneralInfoStepIdentifier]) {
         return [[APCScene alloc] initWithName:@"APCSignUpGeneralInfoViewController" inStoryboard:kAPCOnboardingStoryboardName];
     }
@@ -166,6 +174,7 @@ NSString * const kAPCOnboardingStoryboardName = @"APCOnboarding";
         return [[APCScene alloc] initWithName:@"APCSignUpMedicalInfoViewController" inStoryboard:kAPCOnboardingStoryboardName];
     }
     if ([type isEqualToString:kAPCSignUpCustomInfoStepIdentifier]) {
+        // Check if there is a custom step
         if ([_provider respondsToSelector:@selector(customInfoSceneForOnboarding:)]) {
             return [_provider performSelector:@selector(customInfoSceneForOnboarding:) withObject:onboarding];
         }
@@ -199,6 +208,13 @@ NSString * const kAPCOnboardingStoryboardName = @"APCOnboarding";
 
 - (NSInteger)numberOfServicesInPermissionsListForOnboardingTask:(APCOnboardingTask *)__unused task {
     return [self.permissionsManager.signUpPermissionTypes count];
+}
+
+- (void)onboarding:(APCOnboarding * __unused)onboarding didFinishStepWithResult:(ORKStepResult*)stepResult {
+    if ([stepResult.identifier isEqualToString:APCDataGroupsStepIdentifier]) {
+        [self.dataGroupsManager setSurveyAnswerWithStepResult:stepResult];
+        self.user.dataGroups = self.dataGroupsManager.dataGroups;
+    }
 }
 
 @end

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
@@ -52,6 +52,8 @@ NSString * const kAPCOnboardingStoryboardName = @"APCOnboarding";
 
 @property (strong, nonatomic, readwrite) APCPermissionsManager *permissionsManager;
 
+@property (strong, nonatomic, readwrite) APCDataGroupsManager *dataGroupsManager;
+
 @end
 
 
@@ -126,6 +128,13 @@ NSString * const kAPCOnboardingStoryboardName = @"APCOnboarding";
         _permissionsManager = [self.provider permissionsManager];
     }
     return _permissionsManager;
+}
+
+- (APCDataGroupsManager *)dataGroupsManager {
+    if (!_dataGroupsManager) {
+        _dataGroupsManager = [self.provider dataGroupsManagerForUser:self.user];
+    }
+    return _dataGroupsManager;
 }
 
 #pragma mark - APCOnboardingDelegate

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingTask.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingTask.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSUInteger, APCOnboardingTaskType) {
 FOUNDATION_EXPORT NSString *const kAPCSignUpInclusionCriteriaStepIdentifier;
 FOUNDATION_EXPORT NSString *const kAPCSignUpEligibleStepIdentifier;
 FOUNDATION_EXPORT NSString *const kAPCSignUpIneligibleStepIdentifier;
+FOUNDATION_EXPORT NSString *const kAPCSignUpDataGroupsStepIdentifier;
 FOUNDATION_EXPORT NSString *const kAPCSignUpGeneralInfoStepIdentifier;
 FOUNDATION_EXPORT NSString *const kAPCSignUpMedicalInfoStepIdentifier;
 FOUNDATION_EXPORT NSString *const kAPCSignUpCustomInfoStepIdentifier;
@@ -80,6 +81,8 @@ FOUNDATION_EXPORT NSString *const kAPCSignUpShareAppStepIdentifier;
 @property (nonatomic, strong) ORKStep *ineligibleStep;
 
 @property (nonatomic, strong) ORKStep *permissionsPrimingStep;
+
+@property (nonatomic, strong) ORKStep *dataGroupsStep;
 
 @property (nonatomic, strong) ORKStep *generalInfoStep;
 

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingTask.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingTask.m
@@ -36,6 +36,7 @@
 NSString *const kAPCSignUpInclusionCriteriaStepIdentifier   = @"InclusionCriteria";
 NSString *const kAPCSignUpEligibleStepIdentifier            = @"Eligible";
 NSString *const kAPCSignUpIneligibleStepIdentifier          = @"Ineligible";
+NSString *const kAPCSignUpDataGroupsStepIdentifier          = @"DataGroups";
 NSString *const kAPCSignUpGeneralInfoStepIdentifier         = @"GeneralInfo";
 NSString *const kAPCSignUpMedicalInfoStepIdentifier         = @"MedicalInfo";
 NSString *const kAPCSignUpCustomInfoStepIdentifier          = @"CustomInfo";
@@ -128,6 +129,13 @@ NSString *const kAPCSignUpShareAppStepIdentifier            = @"ShareApp";
     }
     
     return _ineligibleStep;
+}
+
+- (ORKStep *)dataGroupsStep {
+    if (_dataGroupsStep) {
+        _dataGroupsStep = [[ORKStep alloc] initWithIdentifier:kAPCSignUpDataGroupsStepIdentifier];
+    }
+    return _dataGroupsStep;
 }
 
 - (ORKStep *)permissionsPrimingStep

--- a/APCAppCore/APCAppCore/UI/Model/APCScene.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCScene.h
@@ -32,6 +32,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <ResearchKit/ResearchKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,21 +41,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface APCScene : NSObject
 
-@property (nonatomic, strong) NSString *identifier;
+@property (nonatomic, copy) NSString *identifier;
+
+@property (nonatomic, strong) ORKStep *step;
 
 /** Refers to the tabbar item (if applicable) */
 @property (nonatomic, strong) UITabBarItem * _Nullable tabBarItem;
 
 /** Refers to StoryboardID. */
-@property (nonatomic, strong) NSString * _Nullable storyboardId;
+@property (nonatomic, copy) NSString * _Nullable storyboardId;
 
 /** The name of the storyboard. */
-@property (nonatomic, strong) NSString *storyboardName;
+@property (nonatomic, copy) NSString * _Nullable storyboardName;
 
 /** Defaults to the bundle this class resides in. */
 @property (nonatomic, strong) NSBundle *bundle;
 
 - (instancetype)initWithName:(NSString *_Nullable)storyboardId inStoryboard:(NSString *)storyboardName;
+- (instancetype)initWithStep:(ORKStep*)step;
 
 /** Instantiates the view controller as defined by this scene. */
 - (UIViewController * _Nullable)instantiateViewController;

--- a/APCAppCore/APCAppCore/UI/Model/APCSignInTask.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCSignInTask.m
@@ -50,9 +50,9 @@ static NSInteger const kMinimumNumberOfSteps = 2; //MedicalInfo + Passcode
     
     if (!step) {
         nextStep = self.signInStep;
-    } else if ([step.identifier isEqualToString:kAPCSignInStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.signInStep.identifier]) {
         nextStep = self.permissionsPrimingStep;
-    } else if ([step.identifier isEqualToString:kAPCSignUpPermissionsPrimingStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.permissionsPrimingStep.identifier]) {
         if (self.user.isSecondaryInfoSaved) {
             nextStep = nil;
         } else{
@@ -60,7 +60,7 @@ static NSInteger const kMinimumNumberOfSteps = 2; //MedicalInfo + Passcode
             self.currentStepNumber += 1;
         }
         
-    } else if ([step.identifier isEqualToString:kAPCSignUpMedicalInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.medicalInfoStep.identifier]) {
         if (self.customStepIncluded) {
             nextStep = self.customInfoStep;
         } else{
@@ -68,21 +68,21 @@ static NSInteger const kMinimumNumberOfSteps = 2; //MedicalInfo + Passcode
             self.user.secondaryInfoSaved = YES;
         }
         self.currentStepNumber += 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpCustomInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.customInfoStep.identifier]) {
         nextStep = self.passcodeStep;
         self.user.secondaryInfoSaved = YES;
         self.currentStepNumber += 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpPasscodeStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.passcodeStep.identifier]) {
         if (self.permissionScreenSkipped) {
             nextStep = nil;
         } else {
             nextStep = self.permissionsStep;
             self.currentStepNumber += 1;
         }
-    } else if ([step.identifier isEqualToString:kAPCSignUpPermissionsStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.permissionsStep.identifier]) {
         nextStep = self.thankyouStep;
         self.currentStepNumber += 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpThankYouStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.thankyouStep.identifier]) {
         nextStep = nil;
     }
     
@@ -93,19 +93,19 @@ static NSInteger const kMinimumNumberOfSteps = 2; //MedicalInfo + Passcode
 {
     ORKStep *prevStep;
     
-    if ([step.identifier isEqualToString:kAPCSignUpMedicalInfoStepIdentifier]) {
+    if ([step.identifier isEqualToString:self.medicalInfoStep.identifier]) {
         prevStep = nil;
-    } else if ([step.identifier isEqualToString:kAPCSignUpCustomInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.customInfoStep.identifier]) {
         prevStep = self.medicalInfoStep;
         self.currentStepNumber -= 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpPasscodeStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.passcodeStep.identifier]) {
         if (self.customStepIncluded) {
             prevStep = self.customInfoStep;
         } else {
             prevStep = self.medicalInfoStep;
         }
         self.currentStepNumber -= 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpPermissionsStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.permissionsStep.identifier]) {
         prevStep = self.passcodeStep;
         self.currentStepNumber -= 1;
     }

--- a/APCAppCore/APCAppCore/UI/Model/APCSignUpTask.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCSignUpTask.m
@@ -46,25 +46,29 @@ static NSInteger const kMinimumNumberOfSteps = 3; //Gen Info + MedicalInfo + Pas
     
     if (!step) {
         nextStep = self.inclusionCriteriaStep;
-    } else if ([step.identifier isEqualToString:kAPCSignUpInclusionCriteriaStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.inclusionCriteriaStep.identifier]) {
         if (self.eligible) {
             nextStep = self.eligibleStep;
         } else{
             nextStep = self.ineligibleStep;
         }
-    } else if ([step.identifier isEqualToString:kAPCSignUpEligibleStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.eligibleStep.identifier]) {
         self.currentStepNumber += 1;
         nextStep = self.permissionsPrimingStep;
         
-    } else if ([step.identifier isEqualToString:kAPCSignUpPermissionsPrimingStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.permissionsPrimingStep.identifier]) {
+        self.currentStepNumber += 1;
+        nextStep = self.dataGroupsStep;
+    }
+    else if ([step.identifier isEqualToString:self.dataGroupsStep.identifier]) {
         self.currentStepNumber += 1;
         nextStep = self.generalInfoStep;
         
-    } else if ([step.identifier isEqualToString:kAPCSignUpGeneralInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.generalInfoStep.identifier]) {
         self.currentStepNumber += 1;
         nextStep = self.medicalInfoStep;
         
-    } else if ([step.identifier isEqualToString:kAPCSignUpMedicalInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.medicalInfoStep.identifier]) {
         if (self.customStepIncluded) {
             nextStep = self.customInfoStep;
         } else{
@@ -72,18 +76,18 @@ static NSInteger const kMinimumNumberOfSteps = 3; //Gen Info + MedicalInfo + Pas
             self.user.secondaryInfoSaved = YES;
         }
         self.currentStepNumber += 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpCustomInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.customInfoStep.identifier]) {
         nextStep = self.passcodeStep;
         self.user.secondaryInfoSaved = YES;
         self.currentStepNumber += 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpPasscodeStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.passcodeStep.identifier]) {
         if (self.permissionScreenSkipped) {
             nextStep = nil;
         } else {
             nextStep = self.permissionsStep;
             self.currentStepNumber += 1;
         }
-    } else if ([step.identifier isEqualToString:kAPCSignUpIneligibleStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.ineligibleStep.identifier]) {
         nextStep = self.shareAppStep;
         self.currentStepNumber += 1;
     }
@@ -95,33 +99,35 @@ static NSInteger const kMinimumNumberOfSteps = 3; //Gen Info + MedicalInfo + Pas
 {
     ORKStep *prevStep;
     
-    if ([step.identifier isEqualToString:kAPCSignUpInclusionCriteriaStepIdentifier]) {
+    if ([step.identifier isEqualToString:self.inclusionCriteriaStep.identifier]) {
         prevStep = nil;
-    } else if ([step.identifier isEqualToString:kAPCSignUpEligibleStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.eligibleStep.identifier]) {
         prevStep = self.inclusionCriteriaStep;
-    } else if ([step.identifier isEqualToString:kAPCSignUpIneligibleStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.ineligibleStep.identifier]) {
         prevStep = self.inclusionCriteriaStep;
-    } else if ([step.identifier isEqualToString:kAPCSignUpPermissionsPrimingStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.permissionsPrimingStep.identifier]) {
         prevStep = self.eligibleStep;
-    } else if ([step.identifier isEqualToString:kAPCSignUpGeneralInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.dataGroupsStep.identifier]) {
         prevStep = self.permissionsPrimingStep;
-    } else if ([step.identifier isEqualToString:kAPCSignUpMedicalInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.generalInfoStep.identifier]) {
+        prevStep = self.dataGroupsStep;
+    } else if ([step.identifier isEqualToString:self.medicalInfoStep.identifier]) {
         prevStep = self.generalInfoStep;
         self.currentStepNumber -= 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpCustomInfoStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.customInfoStep.identifier]) {
         prevStep = self.medicalInfoStep;
         self.currentStepNumber -= 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpPasscodeStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.passcodeStep.identifier]) {
         if (self.customStepIncluded) {
             prevStep = self.customInfoStep;
         } else {
             prevStep = self.medicalInfoStep;
         }
         self.currentStepNumber -= 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpPermissionsStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.permissionsStep.identifier]) {
         prevStep = self.passcodeStep;
         self.currentStepNumber -= 1;
-    } else if ([step.identifier isEqualToString:kAPCSignUpShareAppStepIdentifier]) {
+    } else if ([step.identifier isEqualToString:self.shareAppStep.identifier]) {
         if (self.eligible) {
             prevStep = self.eligibleStep;
         } else {

--- a/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.h
@@ -50,7 +50,9 @@
 
 @property (nonatomic, copy) NSString *detailText;
 
-@property (nonatomic, copy) NSString *identifier;
+@property (nonatomic, copy) NSString *reuseIdentifier;
+
+@property (nonatomic, copy) NSString *questionIdentifier;
 
 @property (nonatomic, copy) NSString *regularExpression;
 

--- a/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.h
@@ -62,6 +62,13 @@
 
 @property (nonatomic, readwrite, getter=isEditable) BOOL editable;
 
+/**
+ * @Deprecated
+ * Use of "identifier" instead of reuseIdentifier (UITableViewCell naming convention) is confusing and conflicts
+ * with the idea of a unique identifier used elsewhere in the SDK. syoung 01/15/2015
+ */
+@property NSString *identifier __attribute__((deprecated("Please use -reuseIdentifier instead.")));
+
 @end
 
 

--- a/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.m
@@ -51,6 +51,14 @@
     return self;
 }
 
+- (NSString *)identifier {
+    return _reuseIdentifier;
+}
+
+- (void)setIdentifier:(NSString *)identifier {
+    _reuseIdentifier = [identifier copy];
+}
+
 @end
 
 

--- a/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCTableViewItem.m
@@ -35,6 +35,7 @@
 #import "UIColor+APCAppearance.h"
 #import "UIFont+APCAppearance.h"
 #import "APCLocalization.h"
+#import "APCDefaultTableViewCell.h"
 
 @implementation APCTableViewItem
 
@@ -45,6 +46,7 @@
         _style = UITableViewCellStyleValue1;
         _selectionStyle = UITableViewCellSelectionStyleGray;
         _editable = YES;
+        _reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
     }
     return self;
 }

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCUserInfoConstants.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCUserInfoConstants.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(APCTableViewItemType, APCUserInfoItemType) {
     kAPCUserInfoItemTypeWakeUpTime,
     kAPCUserInfoItemTypeGlucoseLevel,
     kAPCUserInfoItemTypeCustomSurvey,
+    kAPCUserInfoItemTypeDataGroups,
     kAPCSettingsItemTypeAutoLock,
     kAPCSettingsItemTypePasscode,
     kAPCSettingsItemTypeReminderOnOff,

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpGeneralInfoViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpGeneralInfoViewController.m
@@ -196,7 +196,7 @@ static CGFloat kHeaderHeight = 157.0f;
         field.placeholder = NSLocalizedStringWithDefaultValue(@"add password", @"APCAppCore", APCBundle(), @"add password", @"");
         field.keyboardType = UIKeyboardTypeASCIICapable;
         field.returnKeyType = UIReturnKeyNext;
-        field.identifier = kAPCTextFieldTableViewCellIdentifier;
+        field.reuseIdentifier = kAPCTextFieldTableViewCellIdentifier;
         field.style = UITableViewCellStyleValue1;
         
         APCTableViewRow *row = [APCTableViewRow new];
@@ -218,7 +218,7 @@ static CGFloat kHeaderHeight = 157.0f;
                 field.datePickerMode = UIDatePickerModeDate;
                 field.style = UITableViewCellStyleValue1;
                 field.selectionStyle = UITableViewCellSelectionStyleGray;
-                field.identifier = kAPCDefaultTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                 
                 NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier: NSCalendarIdentifierGregorian];
                 NSDate *currentDate = [[NSDate date] startOfDay];
@@ -247,7 +247,7 @@ static CGFloat kHeaderHeight = 157.0f;
                 APCTableViewSegmentItem *field = [APCTableViewSegmentItem new];
                 field.style = UITableViewCellStyleValue1;
                 field.segments = [APCUser sexTypesInStringValue];
-                field.identifier = kAPCSegmentedTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCSegmentedTableViewCellIdentifier;
                 
                 if (self.permissionGranted && self.user.biologicalSex) {
                     field.selectedIndex = [APCUser stringIndexFromSexType:self.user.biologicalSex];

--- a/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpMedicalInfoViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/SignUp/APCSignUpMedicalInfoViewController.m
@@ -103,7 +103,7 @@
             {
                 APCTableViewCustomPickerItem *field = [APCTableViewCustomPickerItem new];
                 field.caption = NSLocalizedStringWithDefaultValue(@"Blood Type", @"APCAppCore", APCBundle(), @"Blood Type", @"");
-                field.identifier = kAPCDefaultTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                 field.selectionStyle = UITableViewCellSelectionStyleGray;
                 field.detailDiscloserStyle = YES;
                 
@@ -127,7 +127,7 @@
             {
                 APCTableViewCustomPickerItem *field = [APCTableViewCustomPickerItem new];
                 field.caption = NSLocalizedStringWithDefaultValue(@"Medical Conditions", @"APCAppCore", APCBundle(), @"Medical Conditions", @"");
-                field.identifier = kAPCDefaultTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                 field.selectionStyle = UITableViewCellSelectionStyleGray;
                 field.detailDiscloserStyle = YES;
                 field.pickerData = @[ [APCUser medicalConditions] ];
@@ -150,7 +150,7 @@
             {
                 APCTableViewCustomPickerItem *field = [APCTableViewCustomPickerItem new];
                 field.caption = NSLocalizedStringWithDefaultValue(@"Medications", @"APCAppCore", APCBundle(), @"Medications", @"");
-                field.identifier = kAPCDefaultTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                 field.selectionStyle = UITableViewCellSelectionStyleGray;
                 field.detailDiscloserStyle = YES;
                 field.textAlignnment = NSTextAlignmentRight;
@@ -174,7 +174,7 @@
             {
                 APCTableViewCustomPickerItem *field = [APCTableViewCustomPickerItem new];
                 field.caption = NSLocalizedStringWithDefaultValue(@"Height", @"APCAppCore", APCBundle(), @"Height", @"");
-                field.identifier = kAPCDefaultTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                 field.selectionStyle = UITableViewCellSelectionStyleGray;
                 field.detailDiscloserStyle = YES;
                 field.textAlignnment = NSTextAlignmentRight;
@@ -220,7 +220,7 @@
                 field.caption = NSLocalizedStringWithDefaultValue(@"Weight", @"APCAppCore", APCBundle(), @"Weight", @"");
                 field.placeholder = NSLocalizedStringWithDefaultValue(@"add weight (lb)", @"APCAppCore", APCBundle(), @"add weight (lb)", @"");
                 field.style = UITableViewCellStyleValue1;
-                field.identifier = kAPCTextFieldTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCTextFieldTableViewCellIdentifier;
                 field.regularExpression = kAPCMedicalInfoItemWeightRegEx;
                 field.keyboardType = UIKeyboardTypeDecimalPad;
                 field.textAlignnment = NSTextAlignmentRight;
@@ -241,7 +241,7 @@
                 APCTableViewDatePickerItem *field = [APCTableViewDatePickerItem new];
                 field.caption = NSLocalizedStringWithDefaultValue(@"What time do you generally wake up?", @"APCAppCore", APCBundle(), @"What time do you generally wake up?", @"");
                 field.placeholder = @"07:00 AM";
-                field.identifier = kAPCDefaultTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                 field.selectionStyle = UITableViewCellSelectionStyleGray;
                 field.datePickerMode = UIDatePickerModeTime;
                 field.dateFormat = kAPCMedicalInfoItemSleepTimeFormat;
@@ -271,7 +271,7 @@
                 field.caption = NSLocalizedStringWithDefaultValue(@"What time do you generally go to sleep?", @"APCAppCore", APCBundle(), @"What time do you generally go to sleep?", @"");
                 field.placeholder = @"09:30 PM";
                 field.style = UITableViewCellStyleValue1;
-                field.identifier = kAPCDefaultTableViewCellIdentifier;
+                field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                 field.selectionStyle = UITableViewCellSelectionStyleGray;
                 field.datePickerMode = UIDatePickerModeTime;
                 field.dateFormat = kAPCMedicalInfoItemSleepTimeFormat;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Dashboard/APCDashboardViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Dashboard/APCDashboardViewController.m
@@ -140,7 +140,7 @@ static CGFloat const kAPCLineGraphCellHeight = 225.0f;
 {
     APCTableViewItem *dashboardItem = [self itemForIndexPath:indexPath];
     
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:dashboardItem.identifier];
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:dashboardItem.reuseIdentifier];
 
     if ([dashboardItem isKindOfClass:[APCTableViewDashboardProgressItem class]]) {
         

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -32,6 +32,7 @@
 // 
  
 #import "APCProfileViewController.h"
+#import "APCDataGroupsManager.h"
 #import "APCPermissionsManager.h"
 #import "APCSharingOptionsViewController.h"
 #import "APCLicenseInfoViewController.h"
@@ -88,6 +89,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *studyDetailsViewHeightConstraint;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *studyLabelCenterYConstraint;
 @property (strong, nonatomic) APCPermissionsManager *permissionManager;
+@property (strong, nonatomic) APCDataGroupsManager *dataGroupsManager;
 
 @property (strong, nonatomic) APCDemographicUploader  *demographicUploader;
 @property (nonatomic, assign) BOOL                    profileEditsWerePerformed;
@@ -111,6 +113,8 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     APCAppDelegate *appDelegate = (APCAppDelegate *)[UIApplication sharedApplication].delegate;
     APCUser  *user = appDelegate.dataSubstrate.currentUser;
     self.demographicUploader = [[APCDemographicUploader alloc] initWithUser:user];
+    
+    
 }
 
 - (void)refreshView
@@ -129,6 +133,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     
     [self.profileImageButton.imageView setContentMode:UIViewContentModeScaleAspectFill];
     
+    self.dataGroupsManager = [[APCAppDelegate sharedAppDelegate] dataGroupsManagerForUser:self.user];
     self.items = [self prepareContent];
     [self.tableView reloadData];
     
@@ -148,6 +153,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     }
     
     self.permissionManager = [[APCPermissionsManager alloc] init];
+
     
     [self setupDataFromJSONFile:@"StudyOverview"];
     
@@ -290,7 +296,10 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
             }
             
             if (field) {
-                cell = [tableView dequeueReusableCellWithIdentifier:field.identifier];
+                cell = [tableView dequeueReusableCellWithIdentifier:field.reuseIdentifier];
+                if (!cell) {
+                    cell = [tableView dequeueReusableCellWithIdentifier:kAPCDefaultTableViewCellIdentifier forIndexPath:indexPath];
+                }
                 
                 cell.selectionStyle = field.selectionStyle;
                 cell.textLabel.text = field.caption;
@@ -398,7 +407,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                 }
                 else {
                     if (!cell) {
-                        cell = [[UITableViewCell alloc] initWithStyle:field.style reuseIdentifier:field.identifier];
+                        cell = [[UITableViewCell alloc] initWithStyle:field.style reuseIdentifier:field.reuseIdentifier];
                         
                         cell.textLabel.frame = CGRectMake(12.0, cell.textLabel.frame.origin.y, cell.textLabel.frame.size.width, cell.textLabel.frame.size.height);
                     }
@@ -430,7 +439,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                 {
                     APCTableViewItem *field = [APCTableViewItem new];
                     field.caption = NSLocalizedStringWithDefaultValue(@"Sex", @"APCAppCore", APCBundle(), @"Sex", @"");
-                    field.identifier = kAPCDefaultTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                     field.editable = NO;
                     field.textAlignnment = NSTextAlignmentRight;
                     field.detailText = [APCUser stringValueFromSexType:self.user.biologicalSex];
@@ -447,7 +456,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                 {
                     APCTableViewItem *field = [APCTableViewItem new];
                     field.caption = NSLocalizedStringWithDefaultValue(@"Birthdate", @"APCAppCore", APCBundle(), @"Birthdate", @"");
-                    field.identifier = kAPCDefaultTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                     field.editable = NO;
                     field.textAlignnment = NSTextAlignmentRight;
                     field.detailText = [self.user.birthDate toStringWithFormat:NSDateDefaultDateFormat];
@@ -470,7 +479,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                         field.value = self.user.customSurveyQuestion;
                     }
                     field.keyboardType = UIKeyboardTypeAlphabet;
-                    field.identifier = kAPCTextFieldTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCTextFieldTableViewCellIdentifier;
                     field.selectionStyle = self.isEditing ? UITableViewCellSelectionStyleGray : UITableViewCellSelectionStyleNone;
                     
                     field.style = UITableViewStylePlain;
@@ -488,7 +497,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     field.caption = NSLocalizedStringWithDefaultValue(@"Medical Conditions", @"APCAppCore", APCBundle(), @"Medical Conditions", @"");
                     field.pickerData = @[[APCUser medicalConditions]];
                     field.textAlignnment = NSTextAlignmentRight;
-                    field.identifier = kAPCDefaultTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                     field.selectionStyle = self.isEditing ? UITableViewCellSelectionStyleGray : UITableViewCellSelectionStyleNone;
                     field.editable = NO;
                     
@@ -512,7 +521,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     field.caption = NSLocalizedStringWithDefaultValue(@"Medications", @"APCAppCore", APCBundle(), @"Medications", @"");
                     field.pickerData = @[[APCUser medications]];
                     field.textAlignnment = NSTextAlignmentRight;
-                    field.identifier = kAPCDefaultTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                     field.selectionStyle = self.isEditing ? UITableViewCellSelectionStyleGray : UITableViewCellSelectionStyleNone;
                     field.editable = NO;
                     
@@ -535,7 +544,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
 
                     APCTableViewCustomPickerItem *field = [APCTableViewCustomPickerItem new];
                     field.caption = NSLocalizedStringWithDefaultValue(@"Height", @"APCAppCore", APCBundle(), @"Height", @"");
-                    field.identifier = kAPCDefaultTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                     field.detailDiscloserStyle = YES;
                     field.textAlignnment = NSTextAlignmentRight;
                     field.pickerData = [APCUser heights];
@@ -592,7 +601,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     
                     field.keyboardType = UIKeyboardTypeDecimalPad;
                     field.textAlignnment = NSTextAlignmentRight;
-                    field.identifier = kAPCTextFieldTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCTextFieldTableViewCellIdentifier;
                     field.selectionStyle = self.isEditing ? UITableViewCellSelectionStyleGray : UITableViewCellSelectionStyleNone;
                     
                     APCTableViewRow *row = [APCTableViewRow new];
@@ -608,7 +617,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     field.style = UITableViewCellStyleValue1;
                     field.caption = NSLocalizedStringWithDefaultValue(@"What time do you generally wake up?", @"APCAppCore", APCBundle(), @"What time do you generally wake up?", @"");
                     field.placeholder = NSLocalizedStringWithDefaultValue(@"7:00 AM", @"APCAppCore", APCBundle(), @"7:00 AM", @"");
-                    field.identifier = kAPCDefaultTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                     field.datePickerMode = UIDatePickerModeTime;
                     field.dateFormat = kAPCMedicalInfoItemSleepTimeFormat;
                     field.textAlignnment = NSTextAlignmentRight;
@@ -634,7 +643,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     field.style = UITableViewCellStyleValue1;
                     field.caption = NSLocalizedStringWithDefaultValue(@"What time do you generally go to sleep?", @"APCAppCore", APCBundle(), @"What time do you generally go to sleep?", @"");
                     field.placeholder = NSLocalizedStringWithDefaultValue(@"9:30 PM", @"APCAppCore", APCBundle(), @"9:30 PM", @"");
-                    field.identifier = kAPCDefaultTableViewCellIdentifier;
+                    field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
                     field.datePickerMode = UIDatePickerModeTime;
                     field.dateFormat = kAPCMedicalInfoItemSleepTimeFormat;
                     field.textAlignnment = NSTextAlignmentRight;
@@ -656,28 +665,10 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     
                 case kAPCUserInfoItemTypeDataGroups:
                 {
-                    
-//                    APCTableViewDatePickerItem *field = [APCTableViewDatePickerItem new];
-//                    field.style = UITableViewCellStyleValue1;
-//                    field.caption = NSLocalizedStringWithDefaultValue(@"What time do you generally go to sleep?", @"APCAppCore", APCBundle(), @"What time do you generally go to sleep?", @"");
-//                    field.placeholder = NSLocalizedStringWithDefaultValue(@"9:30 PM", @"APCAppCore", APCBundle(), @"9:30 PM", @"");
-//                    field.identifier = kAPCDefaultTableViewCellIdentifier;
-//                    field.datePickerMode = UIDatePickerModeTime;
-//                    field.dateFormat = kAPCMedicalInfoItemSleepTimeFormat;
-//                    field.textAlignnment = NSTextAlignmentRight;
-//                    field.detailDiscloserStyle = YES;
-//                    field.selectionStyle = self.isEditing ? UITableViewCellSelectionStyleGray : UITableViewCellSelectionStyleNone;
-//                    field.editable = NO;
-//                    
-//                    if (self.user.sleepTime) {
-//                        field.date = self.user.sleepTime;
-//                        field.detailText = [field.date toStringWithFormat:kAPCMedicalInfoItemSleepTimeFormat];
-//                    }
-//                    
-//                    APCTableViewRow *row = [APCTableViewRow new];
-//                    row.item = field;
-//                    row.itemType = kAPCUserInfoItemTypeSleepTime;
-//                    [rowItems addObject:row];
+                    NSArray *rows = [self.dataGroupsManager surveyItems];
+                    if (rows.count > 0) {
+                        [rowItems addObjectsFromArray:rows];
+                    }
                 }
                     break;
                 
@@ -721,7 +712,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     {
         APCTableViewItem *field = [APCTableViewItem new];
         field.caption = NSLocalizedStringWithDefaultValue(@"Activity Reminders", @"APCAppCore", APCBundle(), @"Activity Reminders", @"");
-        field.identifier = kAPCDefaultTableViewCellIdentifier;
+        field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
         field.editable = NO;
         field.showChevron = YES;
         field.selectionStyle = self.isEditing ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleGray;
@@ -743,7 +734,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         
         {
             APCTableViewCustomPickerItem *field = [APCTableViewCustomPickerItem new];
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.selectionStyle = self.isEditing ? UITableViewCellSelectionStyleGray : UITableViewCellSelectionStyleNone;
             field.caption = NSLocalizedStringWithDefaultValue(@"Auto-Lock", @"APCAppCore", APCBundle(), @"Auto-Lock", @"");
             field.detailDiscloserStyle = YES;
@@ -768,7 +759,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         {
             APCTableViewItem *field = [APCTableViewItem new];
             field.caption = NSLocalizedStringWithDefaultValue(@"Change Passcode", @"APCAppCore", APCBundle(), @"Change Passcode", @"");
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.textAlignnment = NSTextAlignmentLeft;
             field.editable = NO;
             field.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -782,7 +773,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         {
             APCTableViewItem *field = [APCTableViewItem new];
             field.caption = NSLocalizedStringWithDefaultValue(@"Download Data", @"APCAppCore", APCBundle(), @"Download Data", @"");
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.textAlignnment = NSTextAlignmentLeft;
             field.editable = NO;
             field.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -797,7 +788,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         {
             APCTableViewItem *field = [APCTableViewItem new];
             field.caption = NSLocalizedStringWithDefaultValue(@"Sharing Options", @"APCAppCore", APCBundle(), @"Sharing Options", @"");
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.textAlignnment = NSTextAlignmentLeft;
             field.editable = NO;
             field.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -818,7 +809,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         {
             APCTableViewItem *field = [APCTableViewItem new];
             field.caption = NSLocalizedStringWithDefaultValue(@"Permissions", @"APCAppCore", APCBundle(), @"Permissions", @"");
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.textAlignnment = NSTextAlignmentRight;
             field.editable = NO;
             field.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -832,7 +823,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         {
             APCTableViewItem *field = [APCTableViewItem new];
             field.caption = NSLocalizedStringWithDefaultValue(@"Review Consent", @"APCAppCore", APCBundle(), @"Review Consent", @"");
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.textAlignnment = NSTextAlignmentRight;
             field.editable = NO;
             field.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -854,7 +845,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         {
             APCTableViewItem *field = [APCTableViewItem new];
             field.caption = NSLocalizedStringWithDefaultValue(@"Privacy Policy", @"APCAppCore", APCBundle(), @"Privacy Policy", @"");
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.textAlignnment = NSTextAlignmentRight;
             field.editable = NO;
             field.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -868,7 +859,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         {
             APCTableViewItem *field = [APCTableViewItem new];
             field.caption = NSLocalizedStringWithDefaultValue(@"License Information", @"APCAppCore", APCBundle(), @"License Information", @"");
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.textAlignnment = NSTextAlignmentRight;
             field.editable = NO;
             field.showChevron = YES;
@@ -1333,6 +1324,10 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                 case kAPCUserInfoItemTypeWakeUpTime:
                     self.user.wakeUpTime = [(APCTableViewDatePickerItem *)item date];
                     break;
+                    
+                case kAPCUserInfoItemTypeDataGroups:
+                    [self.dataGroupsManager setSurveyAnswerWithItem:item];
+                    break;
                 
                 case kAPCSettingsItemTypeAutoLock:
                     break;
@@ -1628,6 +1623,14 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     else {
         if ([self.delegate respondsToSelector:@selector(hasFinishedEditing)]) {
             [self.delegate hasFinishedEditing];
+        }
+        
+        // If the data groups manager has changes, then send changes to server
+        if ([self.dataGroupsManager hasChanges]) {
+            typeof(self) __weak weakSelf = self;
+            [self.user updateDataGroups:self.dataGroupsManager.dataGroups onCompletion:^(NSError * error __unused){
+                [weakSelf refreshView];
+            }];
         }
     }
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -653,6 +653,33 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                     [rowItems addObject:row];
                 }
                     break;
+                    
+                case kAPCUserInfoItemTypeDataGroups:
+                {
+                    
+//                    APCTableViewDatePickerItem *field = [APCTableViewDatePickerItem new];
+//                    field.style = UITableViewCellStyleValue1;
+//                    field.caption = NSLocalizedStringWithDefaultValue(@"What time do you generally go to sleep?", @"APCAppCore", APCBundle(), @"What time do you generally go to sleep?", @"");
+//                    field.placeholder = NSLocalizedStringWithDefaultValue(@"9:30 PM", @"APCAppCore", APCBundle(), @"9:30 PM", @"");
+//                    field.identifier = kAPCDefaultTableViewCellIdentifier;
+//                    field.datePickerMode = UIDatePickerModeTime;
+//                    field.dateFormat = kAPCMedicalInfoItemSleepTimeFormat;
+//                    field.textAlignnment = NSTextAlignmentRight;
+//                    field.detailDiscloserStyle = YES;
+//                    field.selectionStyle = self.isEditing ? UITableViewCellSelectionStyleGray : UITableViewCellSelectionStyleNone;
+//                    field.editable = NO;
+//                    
+//                    if (self.user.sleepTime) {
+//                        field.date = self.user.sleepTime;
+//                        field.detailText = [field.date toStringWithFormat:kAPCMedicalInfoItemSleepTimeFormat];
+//                    }
+//                    
+//                    APCTableViewRow *row = [APCTableViewRow new];
+//                    row.item = field;
+//                    row.itemType = kAPCUserInfoItemTypeSleepTime;
+//                    [rowItems addObject:row];
+                }
+                    break;
                 
                 default:
                     break;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSettingsViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCSettingsViewController.m
@@ -84,7 +84,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         {
             APCTableViewSwitchItem *field = [APCTableViewSwitchItem new];
             field.caption = NSLocalizedStringWithDefaultValue(@"Enable Reminders", @"APCAppCore", APCBundle(), @"Enable Reminders", nil);
-            field.identifier = kAPCSwitchCellIdentifier;
+            field.reuseIdentifier = kAPCSwitchCellIdentifier;
             field.editable = NO;
             
             field.on = reminderOnState;
@@ -100,7 +100,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
             field.caption = NSLocalizedStringWithDefaultValue(@"Time", @"APCAppCore", APCBundle(), @"Time", nil);
             field.pickerData = @[[APCTasksReminderManager reminderTimesArray]];
             field.textAlignnment = NSTextAlignmentRight;
-            field.identifier = kAPCDefaultTableViewCellIdentifier;
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
             field.selectedRowIndices = @[@([[APCTasksReminderManager reminderTimesArray] indexOfObject:appDelegate.tasksReminder.reminderTime])];
 
             APCTableViewRow *row = [APCTableViewRow new];
@@ -124,7 +124,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
             
             APCTableViewSwitchItem *field = [APCTableViewSwitchItem new];
             field.caption = reminder.reminderBody;
-            field.identifier = kAPCSwitchCellIdentifier;
+            field.reuseIdentifier = kAPCSwitchCellIdentifier;
             field.editable = NO;
             
             field.on = [[NSUserDefaults standardUserDefaults]objectForKey:reminder.reminderIdentifier] ? YES : NO;

--- a/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.h
+++ b/APCAppCore/APCAppCore/UI/TasksAndSteps/APCBaseTaskViewController.h
@@ -76,6 +76,7 @@
                         usingContext: (NSManagedObjectContext *) context;
 
 - (void) archiveResults;
+- (void) uploadResultSummary: (NSString *)resultSummary;
 
 /**
  Subclasses should override these methods

--- a/APCAppCore/APCAppCore/UI/ViewControllers/APCUserInfoViewController.m
+++ b/APCAppCore/APCAppCore/UI/ViewControllers/APCUserInfoViewController.m
@@ -145,7 +145,7 @@ static CGFloat const kPickerCellHeight = 164.0f;
         
         if (field) {
             
-            cell = [tableView dequeueReusableCellWithIdentifier:field.identifier];
+            cell = [tableView dequeueReusableCellWithIdentifier:field.reuseIdentifier];
             
             cell.selectionStyle = field.selectionStyle;
             cell.textLabel.text = field.caption;
@@ -235,7 +235,7 @@ static CGFloat const kPickerCellHeight = 164.0f;
                 [self setupSwitchCellAppearance:switchCell];
             } else {
                 if (!cell) {
-                    cell = [[UITableViewCell alloc] initWithStyle:field.style reuseIdentifier:field.identifier];
+                    cell = [[UITableViewCell alloc] initWithStyle:field.style reuseIdentifier:field.reuseIdentifier];
                 }
                 [self setupBasicCellAppearance:cell];
             }

--- a/APCAppCore/APCAppCoreTests/APCDataGroupsManagerTests.m
+++ b/APCAppCore/APCAppCoreTests/APCDataGroupsManagerTests.m
@@ -2,8 +2,33 @@
 //  APCDataGroupsManagerTests.m
 //  APCAppCore
 //
-//  Created by Shannon Young on 1/12/16.
-//  Copyright © 2016 Apple, Inc. All rights reserved.
+// Copyright (c) 2015, Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 #import <XCTest/XCTest.h>

--- a/APCAppCore/APCAppCoreTests/APCDataGroupsManagerTests.m
+++ b/APCAppCore/APCAppCoreTests/APCDataGroupsManagerTests.m
@@ -1,0 +1,179 @@
+//
+//  APCDataGroupsManagerTests.m
+//  APCAppCore
+//
+//  Created by Shannon Young on 1/12/16.
+//  Copyright © 2016 Apple, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <APCAppCore/APCAppCore.h>
+
+@interface APCDataGroupsManagerTests : XCTestCase
+
+@end
+
+@interface MockAPCUser : APCUser
+@property (nonatomic) NSArray *dataGroupsOverride;
+@end
+
+@implementation APCDataGroupsManagerTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testNeedsDataGroup_YES {
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:nil];
+    XCTAssertTrue([manager needsUserInfoDataGroups]);
+}
+
+- (void)testNeedsDataGroup_NO {
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:@[@"control"]];
+    XCTAssertFalse([manager needsUserInfoDataGroups]);
+}
+
+- (void)testIsControlGroup_YES {
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:@[@"control"]];
+    XCTAssertTrue([manager isStudyControlGroup]);
+}
+
+- (void)testIsControlGroup_NO {
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:@[@"studyA"]];
+    XCTAssertFalse([manager isStudyControlGroup]);
+}
+
+- (void)testSurveyItems_ControlGroup {
+    
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:@[@"control", @"studyB"]];
+    NSArray <APCTableViewRow *> * rows = [manager surveyItems];
+    
+    XCTAssertEqual(rows.count, 1);
+    
+    APCTableViewCustomPickerItem *item = (APCTableViewCustomPickerItem *)[[rows firstObject] item];
+    XCTAssertTrue([item isKindOfClass:[APCTableViewCustomPickerItem class]]);
+    
+    XCTAssertEqualObjects(item.identifier, @"control");
+    XCTAssertEqualObjects(item.caption, @"Have you been diagnosed with XYZ?");
+    
+    NSArray *expectedPickerOptions = @[@"Yes", @"No"];
+    XCTAssertEqualObjects(item.pickerData, expectedPickerOptions);
+    
+    NSArray *expectedSelectedIndices = @[@1];
+    XCTAssertEqualObjects(item.selectedRowIndices, expectedSelectedIndices);
+}
+
+- (void)testSurveyItems_StudyAGroup {
+    
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:@[@"studyA", @"studyB"]];
+    NSArray <APCTableViewRow *> * rows = [manager surveyItems];
+    
+    XCTAssertEqual(rows.count, 1);
+    
+    APCTableViewCustomPickerItem *item = (APCTableViewCustomPickerItem *)[[rows firstObject] item];
+    XCTAssertTrue([item isKindOfClass:[APCTableViewCustomPickerItem class]]);
+    
+    XCTAssertEqualObjects(item.identifier, @"control");
+    XCTAssertEqualObjects(item.caption, @"Have you been diagnosed with XYZ?");
+    
+    NSArray *expectedPickerOptions = @[@"Yes", @"No"];
+    XCTAssertEqualObjects(item.pickerData, expectedPickerOptions);
+    
+    NSArray *expectedSelectedIndices = @[@0];
+    XCTAssertEqualObjects(item.selectedRowIndices, expectedSelectedIndices);
+}
+
+- (void)testSetSurveyAnswer_ChangeToControl
+{
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:@[@"studyA", @"studyB"]];
+    
+    // Change the survey answer
+    [manager setSurveyAnswerWithIdentifier:@"control" selectedIndices:@[@1]];
+    
+    // Check results using set b/c order of the groups does not matter
+    NSSet *expectedGroups = [NSSet setWithArray:@[@"control", @"studyB"]];
+    NSSet *actualGroups = [NSSet setWithArray:manager.dataGroups];
+    XCTAssertEqualObjects(actualGroups, expectedGroups);
+    XCTAssertTrue(manager.hasChanges);
+}
+
+- (void)testSetSurveyAnswer_ChangeToStudyA
+{
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:@[@"control", @"studyB"]];
+    
+    // Change the survey answer
+    [manager setSurveyAnswerWithIdentifier:@"control" selectedIndices:@[@0]];
+    
+    // Check the results using a set b/c the order of the groups does not matter
+    NSSet *expectedGroups = [NSSet setWithArray:@[@"studyA", @"studyB"]];
+    NSSet *actualGroups = [NSSet setWithArray:manager.dataGroups];
+    XCTAssertEqualObjects(actualGroups, expectedGroups);
+    XCTAssertTrue(manager.hasChanges);
+}
+
+- (void)testSetSurveyAnswer_NoChange
+{
+    APCDataGroupsManager * manager = [self createDataGroupsManagerWithDataGroups:@[@"control", @"studyB"]];
+    
+    // Change the survey answer
+    [manager setSurveyAnswerWithIdentifier:@"control" selectedIndices:@[@1]];
+    
+    // Check the results using a set b/c the order of the groups does not matter
+    NSSet *expectedGroups = [NSSet setWithArray:@[@"control", @"studyB"]];
+    NSSet *actualGroups = [NSSet setWithArray:manager.dataGroups];
+    XCTAssertEqualObjects(actualGroups, expectedGroups);
+    XCTAssertFalse(manager.hasChanges);
+}
+
+- (APCDataGroupsManager*)createDataGroupsManagerWithDataGroups:(NSArray*)dataGroups {
+    
+    NSDictionary *mapping = @{
+        @"items": @[@{ @"group_name"            : @"control",
+                       @"is_control_group"      : @(true),
+                       },
+                    @{ @"group_name"            : @"studyA",
+                       @"is_control_group"      : @(false),
+                       },
+                    @{ @"group_name"            : @"studyB",
+                       @"is_control_group"      : @(false),
+                       }
+                  ],
+        @"required": @(true),
+        @"questions":
+        @[
+         @{
+             @"identifier": @"control",
+             @"prompt": @"Have you been diagnosed with XYZ?",
+             @"type": @"boolean",
+             @"valueMap": @[@{ @"value" : @YES,
+                               @"groups" : @[@"studyA"]},
+                            @{ @"value" : @NO,
+                               @"groups" : @[@"control"]}
+                            ]
+             },
+         ]
+        };
+    
+    return [[APCDataGroupsManager alloc] initWithDataGroups:dataGroups mapping:mapping];
+}
+
+@end
+
+// Mock is used to override the storage to NSUserDefaults syoung 01/12/2015
+@implementation MockAPCUser
+
+- (NSArray *)dataGroups {
+    return self.dataGroupsOverride;
+}
+
+- (void)setDataGroups:(NSArray *)dataGroups {
+    self.dataGroupsOverride = dataGroups;
+}
+
+@end

--- a/APCAppCore/APCAppCoreTests/APCDataGroupsManagerTests.m
+++ b/APCAppCore/APCAppCoreTests/APCDataGroupsManagerTests.m
@@ -59,10 +59,11 @@
     APCTableViewCustomPickerItem *item = (APCTableViewCustomPickerItem *)[[rows firstObject] item];
     XCTAssertTrue([item isKindOfClass:[APCTableViewCustomPickerItem class]]);
     
-    XCTAssertEqualObjects(item.identifier, @"control");
+    XCTAssertNotNil(item.reuseIdentifier);
+    XCTAssertEqualObjects(item.questionIdentifier, @"control");
     XCTAssertEqualObjects(item.caption, @"Have you been diagnosed with XYZ?");
     
-    NSArray *expectedPickerOptions = @[@"Yes", @"No"];
+    NSArray *expectedPickerOptions = @[@[@"Yes", @"No"]];
     XCTAssertEqualObjects(item.pickerData, expectedPickerOptions);
     
     NSArray *expectedSelectedIndices = @[@1];
@@ -79,10 +80,11 @@
     APCTableViewCustomPickerItem *item = (APCTableViewCustomPickerItem *)[[rows firstObject] item];
     XCTAssertTrue([item isKindOfClass:[APCTableViewCustomPickerItem class]]);
     
-    XCTAssertEqualObjects(item.identifier, @"control");
+    XCTAssertNotNil(item.reuseIdentifier);
+    XCTAssertEqualObjects(item.questionIdentifier, @"control");
     XCTAssertEqualObjects(item.caption, @"Have you been diagnosed with XYZ?");
     
-    NSArray *expectedPickerOptions = @[@"Yes", @"No"];
+    NSArray *expectedPickerOptions = @[@[@"Yes", @"No"]];
     XCTAssertEqualObjects(item.pickerData, expectedPickerOptions);
     
     NSArray *expectedSelectedIndices = @[@0];


### PR DESCRIPTION
I actually tried to limit my changes to the current onboarding and profile architecture, but was only marginally successful. Ended up deciding to add the changes to incorporate data groups in AppCore rather than in mPowerSDK because it was a lot less effort than trying to find all the various managers and whatnot that would need to be overridden in order to implement within mPowerSDK.

Recommend revisiting onboarding as a part of our investigation of ResearchKit 1.3 and incorporated Apple's changes into the AppCore/BridgeSDK structure.
