### PR TITLE
Feature/fphs 118

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -307,6 +307,9 @@
 		A7CFE4B61A8B05F4009A171C /* APCStudyOverviewCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = A7CFE4B21A8B05F4009A171C /* APCStudyOverviewCollectionViewCell.m */; };
 		A7CFE4B71A8B05F4009A171C /* APCStudyOverviewCollectionViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = A7CFE4B31A8B05F4009A171C /* APCStudyOverviewCollectionViewController.h */; };
 		A7CFE4B81A8B05F4009A171C /* APCStudyOverviewCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A7CFE4B41A8B05F4009A171C /* APCStudyOverviewCollectionViewController.m */; };
+		CBC2593A1C58077A0091308E /* MockAPCTasksReminderManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC259391C58077A0091308E /* MockAPCTasksReminderManager.h */; };
+		CBD5DBF21C57FFB400AD654E /* MockAPCTasksReminderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD5DBF11C57FFB400AD654E /* MockAPCTasksReminderManager.m */; };
+		CBD5DBF61C5806AD00AD654E /* APCTasksReminderManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD5DBF51C5806AD00AD654E /* APCTasksReminderManagerTests.m */; };
 		CF03CD021AA23DA2000437FF /* APCMedicationDetailsTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = CF03CCFF1AA23DA2000437FF /* APCMedicationDetailsTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CF03CD031AA23DA2000437FF /* APCMedicationDetailsTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = CF03CD001AA23DA2000437FF /* APCMedicationDetailsTableViewCell.m */; };
 		CF03CD041AA23DA2000437FF /* APCMedicationDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CF03CD011AA23DA2000437FF /* APCMedicationDetailsTableViewCell.xib */; };
@@ -718,7 +721,6 @@
 		FF44E51B1C1B94A700F07DA9 /* APCTaskResultArchiverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FF44E51A1C1B94A700F07DA9 /* APCTaskResultArchiverTests.m */; };
 		FF9469871C1A2D4000CF7075 /* APCAppCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5179B2919D09128001DCCB7 /* APCAppCore.framework */; };
 		FF9469881C1A2F0400CF7075 /* ORKOrderedTask+APCHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FF9469831C1A294E00CF7075 /* ORKOrderedTask+APCHelperTests.m */; };
-		FF9469891C1A2F0900CF7075 /* APCScheduleExpressionEnumeratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5F129DF1A2F78490015982C /* APCScheduleExpressionEnumeratorTests.m */; };
 		FF94698A1C1A2F0900CF7075 /* APCScheduleExpressionListSelectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5F129DA1A2F78490015982C /* APCScheduleExpressionListSelectorTests.m */; };
 		FF94698B1C1A2F0900CF7075 /* APCScheduleExpressionParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5F129DD1A2F78490015982C /* APCScheduleExpressionParserTests.m */; };
 		FF94698C1C1A2F0900CF7075 /* APCScheduleExpressionPointSelectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5F129DC1A2F78490015982C /* APCScheduleExpressionPointSelectorTests.m */; };
@@ -1048,6 +1050,9 @@
 		A7CFE4B21A8B05F4009A171C /* APCStudyOverviewCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCStudyOverviewCollectionViewCell.m; sourceTree = "<group>"; };
 		A7CFE4B31A8B05F4009A171C /* APCStudyOverviewCollectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCStudyOverviewCollectionViewController.h; sourceTree = "<group>"; };
 		A7CFE4B41A8B05F4009A171C /* APCStudyOverviewCollectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = APCStudyOverviewCollectionViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		CBC259391C58077A0091308E /* MockAPCTasksReminderManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MockAPCTasksReminderManager.h; path = "Reminder Tests/MockAPCTasksReminderManager.h"; sourceTree = "<group>"; };
+		CBD5DBF11C57FFB400AD654E /* MockAPCTasksReminderManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MockAPCTasksReminderManager.m; path = "Reminder Tests/MockAPCTasksReminderManager.m"; sourceTree = "<group>"; };
+		CBD5DBF51C5806AD00AD654E /* APCTasksReminderManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = APCTasksReminderManagerTests.m; path = "Reminder Tests/APCTasksReminderManagerTests.m"; sourceTree = "<group>"; };
 		CF03CCFF1AA23DA2000437FF /* APCMedicationDetailsTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = APCMedicationDetailsTableViewCell.h; path = MedicationTrackingAppComponent/APCMedicationDetailsTableViewCell.h; sourceTree = "<group>"; };
 		CF03CD001AA23DA2000437FF /* APCMedicationDetailsTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = APCMedicationDetailsTableViewCell.m; path = MedicationTrackingAppComponent/APCMedicationDetailsTableViewCell.m; sourceTree = "<group>"; };
 		CF03CD011AA23DA2000437FF /* APCMedicationDetailsTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = APCMedicationDetailsTableViewCell.xib; path = MedicationTrackingAppComponent/APCMedicationDetailsTableViewCell.xib; sourceTree = "<group>"; };
@@ -1979,6 +1984,16 @@
 				80A98DB51BFD11580060146F /* APCLocalization.m */,
 			);
 			name = Localization;
+			sourceTree = "<group>";
+		};
+		CB1B241F1C57FE5A009DD367 /* Reminder Tests */ = {
+			isa = PBXGroup;
+			children = (
+				CBD5DBF11C57FFB400AD654E /* MockAPCTasksReminderManager.m */,
+				CBC259391C58077A0091308E /* MockAPCTasksReminderManager.h */,
+				CBD5DBF51C5806AD00AD654E /* APCTasksReminderManagerTests.m */,
+			);
+			name = "Reminder Tests";
 			sourceTree = "<group>";
 		};
 		CF03CCFB1AA23CE7000437FF /* Main Calendar View */ = {
@@ -3026,6 +3041,7 @@
 		F5F129D91A2F78490015982C /* APCAppCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				CB1B241F1C57FE5A009DD367 /* Reminder Tests */,
 				FFFA23A71C20A49700727DA8 /* test files */,
 				F5F129E01A2F78490015982C /* Info.plist */,
 				FF9469821C1A28E800CF7075 /* ActivityTests */,
@@ -3287,6 +3303,7 @@
 				F5B9480A1A73272C0034C522 /* APCScheduleExpressionToken.h in Headers */,
 				F5F12AD01A2F78490015982C /* APCWithdrawSurveyViewController.h in Headers */,
 				368BAFE91A9AD91A00F04ABB /* APCMedTrackerDailyDosageRecord.h in Headers */,
+				CBC2593A1C58077A0091308E /* MockAPCTasksReminderManager.h in Headers */,
 				F5B947F61A73272C0034C522 /* APCParametersDashboardTableViewController.h in Headers */,
 				F5F12AF21A2F78490015982C /* APCBaseTaskViewController.h in Headers */,
 				F5F12AF41A2F78490015982C /* APCBaseWithProgressTaskViewController.h in Headers */,
@@ -3883,12 +3900,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CBD5DBF21C57FFB400AD654E /* MockAPCTasksReminderManager.m in Sources */,
 				FF94698E1C1A2F0D00CF7075 /* NSDateComponentsHelperTests.m in Sources */,
 				FF44E51B1C1B94A700F07DA9 /* APCTaskResultArchiverTests.m in Sources */,
 				FF94698A1C1A2F0900CF7075 /* APCScheduleExpressionListSelectorTests.m in Sources */,
 				FF9469881C1A2F0400CF7075 /* ORKOrderedTask+APCHelperTests.m in Sources */,
-				FF9469891C1A2F0900CF7075 /* APCScheduleExpressionEnumeratorTests.m in Sources */,
 				0833AE1E1A76C016001D8AA0 /* (null) in Sources */,
+				CBD5DBF61C5806AD00AD654E /* APCTasksReminderManagerTests.m in Sources */,
 				FF94698B1C1A2F0900CF7075 /* APCScheduleExpressionParserTests.m in Sources */,
 				FF94698D1C1A2F0900CF7075 /* APCScheduleExpressionRealLifeTests.m in Sources */,
 				FF94698C1C1A2F0900CF7075 /* APCScheduleExpressionPointSelectorTests.m in Sources */,

--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		A7CFE4B71A8B05F4009A171C /* APCStudyOverviewCollectionViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = A7CFE4B31A8B05F4009A171C /* APCStudyOverviewCollectionViewController.h */; };
 		A7CFE4B81A8B05F4009A171C /* APCStudyOverviewCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A7CFE4B41A8B05F4009A171C /* APCStudyOverviewCollectionViewController.m */; };
 		CBC2593A1C58077A0091308E /* MockAPCTasksReminderManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CBC259391C58077A0091308E /* MockAPCTasksReminderManager.h */; };
+		CBC2593B1C5838940091308E /* APCScheduleExpressionEnumeratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5F129DF1A2F78490015982C /* APCScheduleExpressionEnumeratorTests.m */; };
 		CBD5DBF21C57FFB400AD654E /* MockAPCTasksReminderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD5DBF11C57FFB400AD654E /* MockAPCTasksReminderManager.m */; };
 		CBD5DBF61C5806AD00AD654E /* APCTasksReminderManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD5DBF51C5806AD00AD654E /* APCTasksReminderManagerTests.m */; };
 		CF03CD021AA23DA2000437FF /* APCMedicationDetailsTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = CF03CCFF1AA23DA2000437FF /* APCMedicationDetailsTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3904,6 +3905,7 @@
 				FF94698E1C1A2F0D00CF7075 /* NSDateComponentsHelperTests.m in Sources */,
 				FF44E51B1C1B94A700F07DA9 /* APCTaskResultArchiverTests.m in Sources */,
 				FF94698A1C1A2F0900CF7075 /* APCScheduleExpressionListSelectorTests.m in Sources */,
+				CBC2593B1C5838940091308E /* APCScheduleExpressionEnumeratorTests.m in Sources */,
 				FF9469881C1A2F0400CF7075 /* ORKOrderedTask+APCHelperTests.m in Sources */,
 				0833AE1E1A76C016001D8AA0 /* (null) in Sources */,
 				CBD5DBF61C5806AD00AD654E /* APCTasksReminderManagerTests.m in Sources */,

--- a/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.h
@@ -92,6 +92,8 @@ static NSUInteger const kDateHelperDaysInAWeek = 7;
 
 +(instancetype) todayAtMidnight;
 +(instancetype) tomorrowAtMidnight;
++(instancetype)todayAtMidnightFromDate:(NSDate*)date;
++(instancetype)tomorrowAtMidnightFromDate:(NSDate*)date;
 +(instancetype) yesterdayAtMidnight;
 +(instancetype) weekAgoAtMidnight;
 

--- a/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.h
@@ -36,6 +36,11 @@
 extern NSString * const NSDateDefaultDateFormat;
 extern NSString * const DateFormatISO8601DateOnly;
 
+/*
+ * Seems self-explanitory, but adding as a constant anyways
+ */
+static NSUInteger const kDateHelperDaysInAWeek = 7;
+
 @interface NSDate (Helper)
 
 /**
@@ -53,6 +58,7 @@ extern NSString * const DateFormatISO8601DateOnly;
  Got the rules from http://en.wikipedia.org/wiki/ISO_8601
  */
 - (NSString *) toStringInISO8601Format;
+
 
 /**
  Tries to interpret the specified string with any of
@@ -88,7 +94,10 @@ extern NSString * const DateFormatISO8601DateOnly;
 +(instancetype) tomorrowAtMidnight;
 +(instancetype) yesterdayAtMidnight;
 +(instancetype) weekAgoAtMidnight;
+
 +(instancetype) priorSundayAtMidnightFromDate:(NSDate *)date;
++(instancetype) nextSundayAtMidnightFromDate:(NSDate *)date;
+
 + (instancetype) dateWithYear:(NSInteger)year month:(NSInteger)month day:(NSInteger)day;
 
 - (BOOL) isEarlierThanDate: (NSDate*) otherDate;

--- a/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.m
@@ -119,13 +119,7 @@ typedef enum : NSUInteger {
 
 - (NSDate *)dateByAddingDays:(NSInteger)inDays
 {
-    static NSCalendar *cal;
-    static dispatch_once_t once;
-    dispatch_once(&once, ^
-                  {
-                      cal = [NSCalendar currentCalendar];
-                  });
-    
+    NSCalendar* cal = [NSCalendar currentCalendar];
     NSDateComponents *components = [cal components:(NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear) fromDate:self];
     [components setDay:[components day] + inDays];
     return [cal dateFromComponents:components];

--- a/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.m
@@ -68,8 +68,6 @@ typedef enum : NSUInteger {
     APCDateDirectionBackwards,
 }   APCDateDirection;
 
-
-
 @implementation NSDate (Helper)
 
 /**
@@ -343,6 +341,12 @@ typedef enum : NSUInteger {
     NSDateComponents *components = [cal components:(NSCalendarUnitWeekOfYear | NSCalendarUnitMonth | NSCalendarUnitYear) fromDate:date];
     [components setWeekday:1];//Sunday
     return [cal dateFromComponents:components];
+}
+
++(instancetype)nextSundayAtMidnightFromDate:(NSDate *)date
+{
+    NSDate* priorSunday = [self priorSundayAtMidnightFromDate:date];
+    return [priorSunday dateByAddingDays:kDateHelperDaysInAWeek];
 }
 
 - (BOOL) isEarlierThanDate: (NSDate*) otherDate

--- a/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSDate+Helper.m
@@ -302,19 +302,27 @@ typedef enum : NSUInteger {
     return [cal dateFromComponents:components];
 }
 
++(instancetype)todayAtMidnightFromDate:(NSDate*)date
+{
+    return [self startOfDay:date];
+}
+
++(instancetype)tomorrowAtMidnightFromDate:(NSDate*)date
+{
+    NSCalendar *cal = [NSCalendar currentCalendar];
+    NSDateComponents *components = [cal components:(NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear) fromDate:date];
+    [components setDay:[components day] + 1];
+    return [cal dateFromComponents:components];
+}
+
 +(instancetype)todayAtMidnight
 {
-    NSDate *today = [NSDate date];
-    return [self startOfDay:today];
+    return [self todayAtMidnightFromDate:[NSDate date]];
 }
 
 +(instancetype)tomorrowAtMidnight
 {
-    NSDate *today = [NSDate date];
-    NSCalendar *cal = [NSCalendar currentCalendar];
-    NSDateComponents *components = [cal components:(NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear) fromDate:today];
-    [components setDay:[components day] + 1];
-    return [cal dateFromComponents:components];
+    return [self tomorrowAtMidnightFromDate:[NSDate date]];
 }
 
 +(instancetype)yesterdayAtMidnight

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
@@ -75,4 +75,10 @@ static NSUInteger const kAPCTaskReminderDayOfWeekSaturday    = 7;
 + (NSSet *) taskReminderCategories;
 
 - (void)handleActivitiesUpdateWithTodaysTaskGroups:(NSArray *) todaysTaskGroups;
+
+/*
+ * Get the name of the study
+ */
++ (NSString *)studyName;
+
 @end

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
@@ -61,6 +61,14 @@ static NSUInteger const kAPCTaskReminderDayOfWeekSaturday    = 7;
  */
 @property (nonatomic) BOOL updatingRemindersRemovesAllLocalNotifications;
 
+/*
+ * Update reminder messaging
+ * This defualts to...
+ * "Please complete your TeamStudy activities today. Thank you for participating in the TeamStudy study!"
+ */
+- (void) setReminderMessage:(NSString*)reminderMessage
+            andDelayMessage:(NSString*)delayMessage;
+
 - (void) updateTasksReminder;
 - (void)manageTaskReminder:(APCTaskReminder *)reminder;
 + (NSArray*) reminderTimesArray;

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
@@ -33,10 +33,33 @@
  
 #import <Foundation/Foundation.h>
 #import "APCTaskReminder.h"
+
+// These must be reflected by NSCalendar NSCalendarUnitWeekday, except for the EveryDay value
+static NSUInteger const kAPCTaskReminderDayOfWeekEveryDay    = 0;
+static NSUInteger const kAPCTaskReminderDayOfWeekSunday      = 1;
+static NSUInteger const kAPCTaskReminderDayOfWeekMonday      = 2;
+static NSUInteger const kAPCTaskReminderDayOfWeekTuesday     = 3;
+static NSUInteger const kAPCTaskReminderDayOfWeekWednesday   = 4;
+static NSUInteger const kAPCTaskReminderDayOfWeekThursday    = 5;
+static NSUInteger const kAPCTaskReminderDayOfWeekFriday      = 6;
+static NSUInteger const kAPCTaskReminderDayOfWeekSaturday    = 7;
+
 @interface APCTasksReminderManager : NSObject
 @property (nonatomic) BOOL reminderOn;
 @property (nonatomic, strong) NSString * reminderTime; //Should be an element of reminderTimesArray
 @property (strong, nonatomic, getter=reminders) NSMutableArray *reminders;
+
+/**
+ * The days of the week to repeat the reminder, defaults to include every day
+ * Object in the array must be of type APCTaskReminderDayOfWeek
+ */
+@property (nonatomic, strong) NSArray* daysOfTheWeekToRepeat;
+
+/*
+ * If true, all local notifications in this app (even ones that are not reminders) will be removed
+ * If false, the app will try and find only reminder notifications to delete; however this has inconsistant behavior
+ */
+@property (nonatomic) BOOL updatingRemindersRemovesAllLocalNotifications;
 
 - (void) updateTasksReminder;
 - (void)manageTaskReminder:(APCTaskReminder *)reminder;

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.h
@@ -64,7 +64,7 @@ static NSUInteger const kAPCTaskReminderDayOfWeekSaturday    = 7;
 /*
  * Update reminder messaging
  * This defualts to...
- * "Please complete your TeamStudy activities today. Thank you for participating in the TeamStudy study!"
+ * "Please complete your StudyName activities today. Thank you for participating in the StudyName study!"
  */
 - (void) setReminderMessage:(NSString*)reminderMessage
             andDelayMessage:(NSString*)delayMessage;

--- a/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCTasksReminderManager.m
@@ -73,8 +73,12 @@ NSString * gTaskReminderDelayMessage;
     self = [super init];
     if (self)
     {
-        [self setReminderMessage:NSLocalizedStringWithDefaultValue(@"Please complete your %@ activities today. Thank you for participating in the %@ study! %@", @"APCAppCore", APCBundle(), @"Please complete your %@ activities today. Thank you for participating in the %@ study! %@", @"Text for daily reminder to complete activities, to be filled in with the name of the study, the name of the study again, and the concatenation of the bodies of the individual reminders of activities yet to complete.")
-                 andDelayMessage:NSLocalizedStringWithDefaultValue(@"Remind me in 1 hour", @"APCAppCore", APCBundle(), @"Remind me in 1 hour", @"\"Snooze\" prompt for reminder notification")];
+        NSString* reminderMessage = [NSString stringWithFormat:NSLocalizedStringWithDefaultValue(@"Please complete your %@ activities today. Thank you for participating in the %@ study! %@", @"APCAppCore", APCBundle(), @"Please complete your %@ activities today. Thank you for participating in the %@ study!", @"Text for daily reminder to complete activities, to be filled in with the name of the study, the name of the study again, and the concatenation of the bodies of the individual reminders of activities yet to complete."), [APCTasksReminderManager studyName], [APCTasksReminderManager studyName]];
+        
+        NSString* reminderDelayMessage = NSLocalizedStringWithDefaultValue(@"Remind me in 1 hour", @"APCAppCore", APCBundle(), @"Remind me in 1 hour", @"\"Snooze\" prompt for reminder notification");
+        
+        [self setReminderMessage:reminderMessage
+                 andDelayMessage:reminderDelayMessage];
         
         //posted by APCSettingsViewController on turning reminders on/off
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateTasksReminder) name:APCUpdateTasksReminderNotification object:nil];
@@ -365,7 +369,7 @@ NSString * gTaskReminderDelayMessage;
         }
     }
     
-    return [NSString stringWithFormat:gTaskReminderMessage, [self studyName], [self studyName], reminders];
+    return [NSString stringWithFormat:@"%@%@", gTaskReminderMessage, reminders];
 }
 
 -(NSString *)subtaskReminderMessage{
@@ -382,10 +386,10 @@ NSString * gTaskReminderDelayMessage;
         }
     }
     
-    return [NSString stringWithFormat:gTaskReminderMessage, [self studyName], [self studyName], reminders];
+    return [NSString stringWithFormat:@"%@%@", gTaskReminderMessage, reminders];
 }
 
-- (NSString *)studyName {
++ (NSString *)studyName {
     NSString *filePath = [[APCAppDelegate sharedAppDelegate] pathForResource:@"StudyOverview" ofType:@"json"];
     NSString *JSONString = [[NSString alloc] initWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
     

--- a/APCAppCore/APCAppCoreTests/Reminder Tests/APCTasksReminderManagerTests.m
+++ b/APCAppCore/APCAppCoreTests/Reminder Tests/APCTasksReminderManagerTests.m
@@ -223,6 +223,36 @@ static NSString* const kBalanceName = @"Balance Assessment";
     XCTAssertEqual(NO,  [sundayAt5Pm.alertBody containsString:kBalanceName]);
 }
 
+- (void) testTimeZoneChange
+{
+    NSTimeZone* oldTimeZone = [NSTimeZone defaultTimeZone];
+    NSTimeZone* newTimeZone = [NSTimeZone timeZoneWithName:@"America/Denver"];
+    [NSTimeZone setDefaultTimeZone:newTimeZone];
+    self.reminderManager.mockTimeZone = newTimeZone;
+    
+    // Saturday
+    self.reminderManager.mockNow = [NSDate dateWithISO8601String:@"2016-01-23T10:00:00+00:00"];
+    
+    self.reminderManager.daysOfTheWeekToRepeat = @[@(kAPCTaskReminderDayOfWeekSunday),
+                                                   @(kAPCTaskReminderDayOfWeekTuesday)];
+    
+    [self.reminderManager updateTasksReminder];
+    
+    XCTAssertEqual(2, self.reminderManager.scheduledLocalNotification.count);
+    
+    UILocalNotification* sundayAt5Pm = self.reminderManager.scheduledLocalNotification[0];
+    UILocalNotification* tuesdayAt5Pm = self.reminderManager.scheduledLocalNotification[1];
+    
+    NSDate* nextSundayAt5PM = [NSDate dateWithISO8601String:@"2016-01-25T00:00:00+00:00"];
+    XCTAssertEqual(nextSundayAt5PM, sundayAt5Pm.fireDate);
+    
+    NSDate* nextTuesdayAt5PM = [NSDate dateWithISO8601String:@"2016-01-27T00:00:00+00:00"];
+    XCTAssertEqual(nextTuesdayAt5PM, tuesdayAt5Pm.fireDate);
+    
+    [NSTimeZone setDefaultTimeZone:oldTimeZone];
+    self.reminderManager.mockTimeZone = oldTimeZone;
+}
+
 - (void) testMPowerDaily
 {
     // Saturday

--- a/APCAppCore/APCAppCoreTests/Reminder Tests/APCTasksReminderManagerTests.m
+++ b/APCAppCore/APCAppCoreTests/Reminder Tests/APCTasksReminderManagerTests.m
@@ -1,0 +1,240 @@
+//
+//  APCTasksReminderManagerTests.m
+//  APCAppCore
+//
+//  Created by Michael L DePhillips on 1/26/16.
+//  Copyright © 2016 Apple, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "MockAPCTasksReminderManager.h"
+
+static NSString* const kWalkingTaskReminder = @"WalkingTaskReminder";
+static NSString* const kCardiacTaskReminder = @"CardiacTaskReminder";
+static NSString* const kBalanceTaskReminder = @"BalanceTaskReminder";
+
+static NSString* const kWalkingName = @"Walking Assessment";
+static NSString* const kCardiacName = @"Cardiac Health Activity";
+static NSString* const kBalanceName = @"Balance Assessment";
+
+@interface APCTasksReminderManagerTests : XCTestCase
+@property (nonatomic, strong) MockAPCTasksReminderManager* reminderManager;
+@end
+
+@implementation APCTasksReminderManagerTests
+
+/** Put setup code here. This method is called before the invocation of each test method in the class. */
+- (void) setUp
+{
+    [super setUp];
+    
+    self.reminderManager = [[MockAPCTasksReminderManager alloc] init];
+    
+    self.reminderManager.updatingRemindersRemovesAllLocalNotifications = YES;
+    
+    self.reminderManager.reminderTime = [APCTasksReminderManager reminderTimesArray][17]; // 17 = 5pm
+    
+    [self.reminderManager setReminderMessage:@"Reminder Message"
+                             andDelayMessage:@"Delay Reminder 1 Hour"];
+    
+    [self.reminderManager handleActivitiesUpdateWithTodaysTaskGroups:@[]];
+    
+    APCTaskReminder *walkingAssessmentReminder = [[APCTaskReminder alloc] initWithTaskID:kWalkingTaskReminder reminderBody:kWalkingName];
+    APCTaskReminder *cardiacHealthReminder = [[APCTaskReminder alloc] initWithTaskID:kCardiacTaskReminder reminderBody:kCardiacName];
+    APCTaskReminder *balanceAssessmentReminder = [[APCTaskReminder alloc] initWithTaskID:kBalanceTaskReminder reminderBody:kBalanceName];
+    
+    [self.reminderManager setReminderKey:kWalkingTaskReminder toOn:YES];
+    [self.reminderManager setReminderKey:kCardiacTaskReminder toOn:YES];
+    [self.reminderManager setReminderKey:kBalanceTaskReminder toOn:YES];
+    
+    [self.reminderManager setAllReminders:YES];
+    
+    self.reminderManager.tasksFullComplete = @{
+                                               kWalkingTaskReminder : @(NO),
+                                               kCardiacTaskReminder : @(NO),
+                                               kBalanceTaskReminder : @(NO)};
+    
+    [self.reminderManager.reminders removeAllObjects];
+    [self.reminderManager manageTaskReminder:walkingAssessmentReminder];
+    [self.reminderManager manageTaskReminder:cardiacHealthReminder];
+    [self.reminderManager manageTaskReminder:balanceAssessmentReminder];
+}
+
+/** Put teardown code here. This method is called after the invocation of each test method in the class. */
+- (void) tearDown
+{
+    [super tearDown];
+}
+
+- (void) testRemindersTurnedOff
+{
+    [self.reminderManager setAllReminders:NO];
+    [self.reminderManager updateTasksReminder];
+    XCTAssertEqual(0, self.reminderManager.scheduledLocalNotification.count);
+}
+
+- (void) testFphsSundayTuesdayNoneCompleteOnSaturday
+{
+    // Saturday
+    self.reminderManager.mockNow = [NSDate dateWithISO8601String:@"2016-01-23T10:00:00+00:00"];
+    
+    self.reminderManager.daysOfTheWeekToRepeat = @[@(kAPCTaskReminderDayOfWeekSunday),
+                                                   @(kAPCTaskReminderDayOfWeekTuesday)];
+    
+    [self.reminderManager updateTasksReminder];
+    
+    XCTAssertEqual(2, self.reminderManager.scheduledLocalNotification.count);
+    
+    UILocalNotification* sundayAt5Pm = self.reminderManager.scheduledLocalNotification[0];
+    UILocalNotification* tuesdayAt5Pm = self.reminderManager.scheduledLocalNotification[1];
+    
+    NSDate* nextSundayAt5PM = [NSDate dateWithISO8601String:@"2016-01-24T22:00:00+00:00"];
+    XCTAssertEqual(nextSundayAt5PM, sundayAt5Pm.fireDate);
+    
+    NSDate* nextTuesdayAt5PM = [NSDate dateWithISO8601String:@"2016-01-26T22:00:00+00:00"];
+    XCTAssertEqual(nextTuesdayAt5PM, tuesdayAt5Pm.fireDate);
+}
+
+- (void) testFphsSundayTuesdayNoneCompleteOnTuesday
+{
+    // Saturday
+    self.reminderManager.mockNow = [NSDate dateWithISO8601String:@"2016-01-26T10:00:00+00:00"];
+    
+    self.reminderManager.daysOfTheWeekToRepeat = @[@(kAPCTaskReminderDayOfWeekSunday),
+                                                   @(kAPCTaskReminderDayOfWeekTuesday)];
+    
+    [self.reminderManager updateTasksReminder];
+    
+    XCTAssertEqual(2, self.reminderManager.scheduledLocalNotification.count);
+    
+    UILocalNotification* sundayAt5Pm = self.reminderManager.scheduledLocalNotification[0];
+    UILocalNotification* tuesdayAt5Pm = self.reminderManager.scheduledLocalNotification[1];
+    
+    NSDate* nextSundayAt5PM = [NSDate dateWithISO8601String:@"2016-01-31T22:00:00+00:00"];
+    XCTAssertEqual(nextSundayAt5PM, sundayAt5Pm.fireDate);
+    
+    NSDate* nextTuesdayAt5PM = [NSDate dateWithISO8601String:@"2016-01-26T22:00:00+00:00"];
+    XCTAssertEqual(nextTuesdayAt5PM, tuesdayAt5Pm.fireDate);
+}
+
+- (void) testFphsSundayTuesdayAllCompleteOnSundayScheduleNextWeek
+{
+    // Sunday
+    self.reminderManager.mockNow = [NSDate dateWithISO8601String:@"2016-01-24T10:00:00+00:00"];
+    
+    self.reminderManager.daysOfTheWeekToRepeat = @[@(kAPCTaskReminderDayOfWeekSunday),
+                                                   @(kAPCTaskReminderDayOfWeekTuesday)];
+    
+    self.reminderManager.tasksFullComplete = @{
+                                               kWalkingTaskReminder : @(YES),
+                                               kCardiacTaskReminder : @(YES),
+                                               kBalanceTaskReminder : @(YES)};
+    
+    [self.reminderManager updateTasksReminder];
+    
+    XCTAssertEqual(2, self.reminderManager.scheduledLocalNotification.count);
+    
+    UILocalNotification* sundayAt5Pm = self.reminderManager.scheduledLocalNotification[0];
+    UILocalNotification* tuesdayAt5Pm = self.reminderManager.scheduledLocalNotification[1];
+    
+    NSDate* nextSundayAt5PM = [NSDate dateWithISO8601String:@"2016-01-31T22:00:00+00:00"];
+    XCTAssertEqual(nextSundayAt5PM, sundayAt5Pm.fireDate);
+    
+    NSDate* nextTuesdayAt5PM = [NSDate dateWithISO8601String:@"2016-02-2T22:00:00+00:00"];
+    XCTAssertEqual(nextTuesdayAt5PM, tuesdayAt5Pm.fireDate);
+    
+    XCTAssertEqual(NO, [sundayAt5Pm.alertBody containsString:kWalkingName]);
+    XCTAssertEqual(NO,  [sundayAt5Pm.alertBody containsString:kCardiacName]);
+    XCTAssertEqual(NO,  [sundayAt5Pm.alertBody containsString:kBalanceName]);
+    
+    XCTAssertEqual(NSCalendarUnitWeekOfYear, sundayAt5Pm.repeatInterval);
+    XCTAssertEqual(NSCalendarUnitWeekOfYear, tuesdayAt5Pm.repeatInterval);
+}
+
+- (void) testFphsSundayTuesdayAllCompleteOnTuesdayScheduleNextWeek
+{
+    // Sunday
+    self.reminderManager.mockNow = [NSDate dateWithISO8601String:@"2016-01-26T10:00:00+00:00"];
+    
+    self.reminderManager.daysOfTheWeekToRepeat = @[@(kAPCTaskReminderDayOfWeekSunday),
+                                                   @(kAPCTaskReminderDayOfWeekTuesday)];
+    
+    self.reminderManager.tasksFullComplete = @{
+                                               kWalkingTaskReminder : @(YES),
+                                               kCardiacTaskReminder : @(YES),
+                                               kBalanceTaskReminder : @(YES)};
+    
+    [self.reminderManager updateTasksReminder];
+    
+    XCTAssertEqual(2, self.reminderManager.scheduledLocalNotification.count);
+    
+    UILocalNotification* sundayAt5Pm = self.reminderManager.scheduledLocalNotification[0];
+    UILocalNotification* tuesdayAt5Pm = self.reminderManager.scheduledLocalNotification[1];
+    
+    NSDate* nextSundayAt5PM = [NSDate dateWithISO8601String:@"2016-01-31T22:00:00+00:00"];
+    XCTAssertEqual(nextSundayAt5PM, sundayAt5Pm.fireDate);
+    
+    NSDate* nextTuesdayAt5PM = [NSDate dateWithISO8601String:@"2016-02-2T22:00:00+00:00"];
+    XCTAssertEqual(nextTuesdayAt5PM, tuesdayAt5Pm.fireDate);
+    
+    XCTAssertEqual(NO, [sundayAt5Pm.alertBody containsString:kWalkingName]);
+    XCTAssertEqual(NO,  [sundayAt5Pm.alertBody containsString:kCardiacName]);
+    XCTAssertEqual(NO,  [sundayAt5Pm.alertBody containsString:kBalanceName]);
+    
+    XCTAssertEqual(NSCalendarUnitWeekOfYear, sundayAt5Pm.repeatInterval);
+    XCTAssertEqual(NSCalendarUnitWeekOfYear, tuesdayAt5Pm.repeatInterval);
+}
+
+- (void) testFphsSundayTuesdayAllTasksIncludedInAlert
+{
+    // Saturday
+    self.reminderManager.mockNow = [NSDate dateWithISO8601String:@"2016-01-23T10:00:00+00:00"];
+    
+    [self.reminderManager updateTasksReminder];
+    
+    UILocalNotification* sundayAt5Pm = self.reminderManager.scheduledLocalNotification[0];
+    
+    XCTAssertEqual(YES, [sundayAt5Pm.alertBody containsString:kWalkingName]);
+    XCTAssertEqual(YES, [sundayAt5Pm.alertBody containsString:kCardiacName]);
+    XCTAssertEqual(YES, [sundayAt5Pm.alertBody containsString:kBalanceName]);
+}
+
+- (void) testFphsSundayTuesdayOneTaskIncludedInAlert
+{
+    // Saturday
+    self.reminderManager.mockNow = [NSDate dateWithISO8601String:@"2016-01-23T10:00:00+00:00"];
+    
+    self.reminderManager.tasksFullComplete = @{
+                                               kWalkingTaskReminder : @(NO),
+                                               kCardiacTaskReminder : @(YES),
+                                               kBalanceTaskReminder : @(YES)};
+    
+    [self.reminderManager updateTasksReminder];
+    
+    UILocalNotification* sundayAt5Pm = self.reminderManager.scheduledLocalNotification[0];
+    
+    XCTAssertEqual(YES, [sundayAt5Pm.alertBody containsString:kWalkingName]);
+    XCTAssertEqual(NO,  [sundayAt5Pm.alertBody containsString:kCardiacName]);
+    XCTAssertEqual(NO,  [sundayAt5Pm.alertBody containsString:kBalanceName]);
+}
+
+- (void) testMPowerDaily
+{
+    // Saturday
+    self.reminderManager.mockNow = [NSDate dateWithISO8601String:@"2016-01-23T10:00:00+00:00"];
+    
+    self.reminderManager.daysOfTheWeekToRepeat = @[@(kAPCTaskReminderDayOfWeekEveryDay)];
+    
+    [self.reminderManager updateTasksReminder];
+    
+    XCTAssertEqual(1, self.reminderManager.scheduledLocalNotification.count);
+    
+    UILocalNotification* saturdayAt5Pm = self.reminderManager.scheduledLocalNotification[0];
+    
+    NSDate* thisSaturdayAt5PM = [NSDate dateWithISO8601String:@"2016-01-23T22:00:00+00:00"];
+    XCTAssertEqual(thisSaturdayAt5PM, saturdayAt5Pm.fireDate);
+    
+    XCTAssertEqual(NSCalendarUnitDay, saturdayAt5Pm.repeatInterval);
+}
+
+@end

--- a/APCAppCore/APCAppCoreTests/Reminder Tests/APCTasksReminderManagerTests.m
+++ b/APCAppCore/APCAppCoreTests/Reminder Tests/APCTasksReminderManagerTests.m
@@ -19,6 +19,7 @@ static NSString* const kBalanceName = @"Balance Assessment";
 
 @interface APCTasksReminderManagerTests : XCTestCase
 @property (nonatomic, strong) MockAPCTasksReminderManager* reminderManager;
+@property (nonatomic, strong) NSTimeZone* originalTimeZone;
 @end
 
 @implementation APCTasksReminderManagerTests
@@ -27,6 +28,9 @@ static NSString* const kBalanceName = @"Balance Assessment";
 - (void) setUp
 {
     [super setUp];
+    
+    self.originalTimeZone = [NSTimeZone defaultTimeZone];
+    [NSTimeZone setDefaultTimeZone:[NSTimeZone timeZoneWithName:@"America/New_York"]];
     
     self.reminderManager = [[MockAPCTasksReminderManager alloc] init];
     
@@ -64,6 +68,7 @@ static NSString* const kBalanceName = @"Balance Assessment";
 - (void) tearDown
 {
     [super tearDown];
+    self.originalTimeZone = self.originalTimeZone;
 }
 
 - (void) testRemindersTurnedOff

--- a/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.h
+++ b/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.h
@@ -1,0 +1,20 @@
+//
+//  MockUIApplication.h
+//  APCAppCore
+//
+//  Created by Michael L DePhillips on 1/26/16.
+//
+
+#import <APCAppCore/APCAppCore.h>
+
+@interface MockAPCTasksReminderManager : APCTasksReminderManager
+
+@property (nonatomic, strong) NSDate* mockNow;
+
+- (void) setReminderKey:(NSString*)reminderKey toOn:(BOOL)on;
+- (void) setAllReminders:(BOOL)on;
+
+@property (nonatomic) NSMutableArray *scheduledLocalNotification;
+@property (nonatomic) NSDictionary *tasksFullComplete;
+
+@end

--- a/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.h
+++ b/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.h
@@ -10,6 +10,7 @@
 @interface MockAPCTasksReminderManager : APCTasksReminderManager
 
 @property (nonatomic, strong) NSDate* mockNow;
+@property (nonatomic, strong) NSTimeZone* mockTimeZone;
 
 - (void) setReminderKey:(NSString*)reminderKey toOn:(BOOL)on;
 - (void) setAllReminders:(BOOL)on;

--- a/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.m
+++ b/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.m
@@ -76,7 +76,7 @@
 
 - (NSTimeZone*) timeZone
 {
-    return [NSTimeZone timeZoneForSecondsFromGMT:0];
+    return [NSTimeZone defaultTimeZone];
 }
 
 -(BOOL)includeTaskInReminder:(APCTaskReminder *)taskReminder {

--- a/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.m
+++ b/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.m
@@ -53,6 +53,15 @@
     return self.mockNow;
 }
 
+- (NSTimeZone*) timeZone
+{
+    if (self.mockTimeZone == nil)
+    {
+        self.mockTimeZone = [NSTimeZone defaultTimeZone];
+    }
+    return self.mockTimeZone;
+}
+
 - (void) setAllReminders:(BOOL)on
 {
     [[self storedDefaults] setObject:@(on) forKey:kTasksReminderDefaultsOnOffKey];
@@ -72,11 +81,6 @@
 - (void) initializeDefaultReminderMessages
 {
     // no implementation
-}
-
-- (NSTimeZone*) timeZone
-{
-    return [NSTimeZone defaultTimeZone];
 }
 
 -(BOOL)includeTaskInReminder:(APCTaskReminder *)taskReminder {

--- a/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.m
+++ b/APCAppCore/APCAppCoreTests/Reminder Tests/MockAPCTasksReminderManager.m
@@ -1,0 +1,111 @@
+//
+//  MockAPCTasksReminderManager.m
+//  APCAppCore
+//
+//  Created by Michael L DePhillips on 1/26/16.
+//  Copyright © 2016 Apple, Inc. All rights reserved.
+//
+
+#import "MockAPCTasksReminderManager.h"
+#import <UIKit/UIKit.h>
+
+@interface APCTasksReminderManager()
+- (instancetype)initWithUserDefaultsWithSuiteName:(NSString*)name;
+- (NSUserDefaults*) storedDefaults;
+@end
+
+@implementation MockAPCTasksReminderManager
+
+- (instancetype) init
+{
+    self = [super initWithUserDefaultsWithSuiteName:[[NSUUID UUID] UUIDString]];
+    [self setAllReminders:YES];
+    _scheduledLocalNotification = [@[] mutableCopy];
+    return self;
+}
+
+- (NSString*) initializeDefaultTime
+{
+    return @"5:00PM";
+}
+
+- (BOOL) notificationsAreEnabled
+{
+    return @YES;
+}
+
+- (void) scheduleLocalNotification:(UILocalNotification*)notification
+{
+    [self.scheduledLocalNotification addObject:notification];
+}
+
+- (void) cancelLocalNotificationsIfExist
+{
+    [self.scheduledLocalNotification removeAllObjects];
+}
+
+- (NSDate*) now
+{
+    if (self.mockNow == nil)
+    {
+        self.mockNow = [NSDate new];
+    }
+    return self.mockNow;
+}
+
+- (void) setAllReminders:(BOOL)on
+{
+    [[self storedDefaults] setObject:@(on) forKey:kTasksReminderDefaultsOnOffKey];
+}
+
+- (void) setReminderKey:(NSString*)reminderKey toOn:(BOOL)on
+{
+    [[self storedDefaults] setObject:@(on) forKey:reminderKey];
+    [[self storedDefaults] synchronize];
+}
+
+- (void) addNotificationCategoryIfNeeded
+{
+    // no implementation
+}
+
+- (void) initializeDefaultReminderMessages
+{
+    // no implementation
+}
+
+- (NSTimeZone*) timeZone
+{
+    return [NSTimeZone timeZoneForSecondsFromGMT:0];
+}
+
+-(BOOL)includeTaskInReminder:(APCTaskReminder *)taskReminder {
+    BOOL includeTask = NO;
+    
+    //the reminderIdentifier shall be added to NSUserDefaults only when the task reminder is set to ON
+    if (![self.storedDefaults objectForKey: taskReminder.taskID]) {
+        //the reminder for this task is off
+        return includeTask;
+    }
+
+    // Instead of the below logic, let's just do a completed dictionary
+    return ![self.tasksFullComplete[taskReminder.taskID] boolValue];
+//    APCTaskGroup *groupForTaskID;
+//    for (APCTaskGroup *group in self.taskGroups) {
+//        
+//        if ([group.task.taskID isEqualToString:taskReminder.taskID]) {
+//            groupForTaskID = group;
+//            break;
+//        }
+//    }
+//    
+//    if (!groupForTaskID) {
+//        includeTask = NO;
+//    } else if (!groupForTaskID.isFullyCompleted ) {//if this task has not been completed but was required, include it in the reminder
+//        includeTask = YES;
+//    }
+//    
+//    return includeTask;
+}
+
+@end


### PR DESCRIPTION
Changes in AppCore to support weekday frequency reminders and also keep old reminder system working by default

For testing purposes, I preformed these 3 tests of satisfaction

Tests can be achieved by setting the date & time in iOS general settings to one minute before the expected time, and watching notification fire after time turns to 5:00 PM in any timezone.

Test Case 1:
New activities received on Sunday.
Notification appears on Sunday at 5PM
Notification appears on Tuesday at 5PM
Notifications appear next Sunday and Tuesday without opening the app

Test Case 2:
New activities received on Sunday.
Notification appears on Sunday at 5PM
Do all activities
No Notification appears on Tuesday at 5PM
Notifications appear next Sunday and Tuesday without opening the app

Test Case 3:
New activities received on Sunday.
Do all activities
No Notification appears on Sunday at 5PM
No Notification appears on Tuesday at 5PM
Notifications appear next Sunday and Tuesday without opening the app
