### PR TITLE
Fix tests' RK/Swift interaction AGAIN

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 		7BEFD7E11AD596070087F46C /* APCPassiveDataSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BEFD7DA1AD596070087F46C /* APCPassiveDataSink.m */; };
 		7BF54F971AA158E50081C935 /* APCHorizontalBottomThinLineView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BF54F951AA158E50081C935 /* APCHorizontalBottomThinLineView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BF54F981AA158E50081C935 /* APCHorizontalBottomThinLineView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BF54F961AA158E50081C935 /* APCHorizontalBottomThinLineView.m */; };
+		803237A61C6E8A6E00208365 /* APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803237A51C6E8A6E00208365 /* APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift */; };
 		806F24331B3388E700B50664 /* APCCMSSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 806F24321B3388E700B50664 /* APCCMSSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80A98DB61BFD11580060146F /* APCLocalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 80A98DB51BFD11580060146F /* APCLocalization.m */; };
 		80A98DCE1BFD49180060146F /* APCOnboarding.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 80A98DD01BFD49180060146F /* APCOnboarding.storyboard */; };
@@ -1036,6 +1037,8 @@
 		7BF54F901AA1354D0081C935 /* APCVerticalThinLineView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCVerticalThinLineView.m; sourceTree = "<group>"; };
 		7BF54F951AA158E50081C935 /* APCHorizontalBottomThinLineView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCHorizontalBottomThinLineView.h; sourceTree = "<group>"; };
 		7BF54F961AA158E50081C935 /* APCHorizontalBottomThinLineView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCHorizontalBottomThinLineView.m; sourceTree = "<group>"; };
+		803237A41C6E8A6900208365 /* APCAppCoreTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "APCAppCoreTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		803237A51C6E8A6E00208365 /* APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift; sourceTree = "<group>"; };
 		806F24321B3388E700B50664 /* APCCMSSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = APCCMSSupport.h; path = CMS/APCCMSSupport.h; sourceTree = "<group>"; };
 		80A98DB01BFCFE430060146F /* APCLocalization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = APCLocalization.h; path = Localization/APCLocalization.h; sourceTree = "<group>"; };
 		80A98DB51BFD11580060146F /* APCLocalization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCLocalization.m; sourceTree = "<group>"; };
@@ -3053,6 +3056,8 @@
 		F5F129D91A2F78490015982C /* APCAppCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				803237A51C6E8A6E00208365 /* APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift */,
+				803237A41C6E8A6900208365 /* APCAppCoreTests-Bridging-Header.h */,
 				CB1B241F1C57FE5A009DD367 /* Reminder Tests */,
 				FFFA23A71C20A49700727DA8 /* test files */,
 				F5F129E01A2F78490015982C /* Info.plist */,
@@ -3475,6 +3480,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = APC;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Apple, Inc.";
 				TargetAttributes = {
@@ -3922,6 +3928,7 @@
 				FF94698A1C1A2F0900CF7075 /* APCScheduleExpressionListSelectorTests.m in Sources */,
 				CBC2593B1C5838940091308E /* APCScheduleExpressionEnumeratorTests.m in Sources */,
 				FF9469881C1A2F0400CF7075 /* ORKOrderedTask+APCHelperTests.m in Sources */,
+				803237A61C6E8A6E00208365 /* APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift in Sources */,
 				0833AE1E1A76C016001D8AA0 /* (null) in Sources */,
 				CBD5DBF61C5806AD00AD654E /* APCTasksReminderManagerTests.m in Sources */,
 				FF94698B1C1A2F0900CF7075 /* APCScheduleExpressionParserTests.m in Sources */,
@@ -4116,6 +4123,7 @@
 		F5179B4019D09128001DCCB7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -4131,12 +4139,15 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = APCAppCoreTests;
+				SWIFT_OBJC_BRIDGING_HEADER = "APCAppCoreTests/APCAppCoreTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		F5179B4119D09128001DCCB7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -4148,6 +4159,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = APCAppCoreTests;
+				SWIFT_OBJC_BRIDGING_HEADER = "APCAppCoreTests/APCAppCoreTests-Bridging-Header.h";
 			};
 			name = Release;
 		};
@@ -4229,6 +4241,7 @@
 		F58767F519E4A20E00254897 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -4244,6 +4257,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = APCAppCoreTests;
+				SWIFT_OBJC_BRIDGING_HEADER = "APCAppCoreTests/APCAppCoreTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Development;
 		};

--- a/APCAppCore/APCAppCoreTests/APCAppCoreTests-Bridging-Header.h
+++ b/APCAppCore/APCAppCoreTests/APCAppCoreTests-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/APCAppCore/APCAppCoreTests/APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift
+++ b/APCAppCore/APCAppCoreTests/APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift
@@ -2,8 +2,33 @@
 //  APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift
 //  APCAppCore
 //
-//  Created by Erin Mounts on 2/12/16.
-//  Copyright © 2016 Sage Bionetworks, Inc. All rights reserved.
+// Copyright (c) 2016 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 import XCTest

--- a/APCAppCore/APCAppCoreTests/APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift
+++ b/APCAppCore/APCAppCoreTests/APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift
@@ -1,0 +1,40 @@
+//
+//  APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase.swift
+//  APCAppCore
+//
+//  Created by Erin Mounts on 2/12/16.
+//  Copyright © 2016 Sage Bionetworks, Inc. All rights reserved.
+//
+
+import XCTest
+
+// ResearchKit uses these, and if we don't import them the tests crash on load due to missing Swift dylibs
+// (Apple PLEASE fix this...)
+import CoreAudio
+import CoreLocation
+
+class APCFudgeTestsToKnowAboutSwiftByAddingASwiftTestCase: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
RK can't have the "Embedded Content Contains Swift" flag turned on in an app for distribution. Instead, we'll trick AppCore test target to include Swift dylib by creating a dummy Swift test case. Also, that dummy test case imports CoreAudio and CoreLocation, because RK uses them and without those imports the tests crash on launch due to missing dylibs.
