### PR TITLE
Test User Detection Feature

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.h
@@ -34,10 +34,26 @@
 #import "APCUser.h"
 #import <BridgeSDK/BridgeSDK.h>
 
+static NSString*  kAPCUserBridgeErrorDomain             = @"kAPCUserBridgeErrorDomain";
+static NSUInteger kAPCUserBridgeHaveNotVerifiedTestUser = 1;
+
 @interface APCUser (Bridge) <SBBAuthManagerDelegateProtocol>
 
 - (void) signUpOnCompletion:(void (^)(NSError * error))completionBlock;
+
 - (void) signUpWithDataGroups:(NSArray<NSString *> *)dataGroups onCompletion:(void (^)(NSError *))completionBlock;
+
+/*
+ * @param includeTestDataGroupCheck if NO, sign up will proceed as normal
+ *                                  if YES, the code will check for "+test" and add the user to the test data
+ * @param userHasAgreedToBeTestUser if YES, test data group will be added if check returns YES
+ *                                  if NO,  complete block will throw kAPCUserBridgeErrorDomain error if check returns YES
+ */
+- (void) signUpWithDataGroups:(NSArray<NSString *> *)dataGroups
+    includeTestDataGroupCheck:(BOOL)includeTestDataGroupCheck
+    userHasAgreedToBeTestUser:(BOOL)userHasAgreedToBeTestUser
+                 onCompletion:(void (^)(NSError *))completionBlock;
+
 - (void) signInOnCompletion:(void (^)(NSError * error))completionBlock;
 - (void) signOutOnCompletion:(void (^)(NSError * error))completionBlock;
 - (void) updateDataGroups:(NSArray<NSString *> *)dataGroups onCompletion:(void (^)(NSError * error))completionBlock;


### PR DESCRIPTION
Added additional sign up method that includes a check for verifying and automatically adding the "test_user" group.

I was originally planning on adding the alert view showing in APCUser+Bridge, but there ended up being too much UI involved, but for an example of implementation, see https://github.com/Sage-Bionetworks/FPHS/pull/172
