### PR TITLE
feature/test_user_detection

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.h
@@ -36,8 +36,24 @@
 
 @interface APCUser (Bridge) <SBBAuthManagerDelegateProtocol>
 
+/*
+ * @param shouldPerform YES if you want to perform test user check when calling sign up with view controller paramater
+ *                      NO if you do not want it to perform this test
+ */
++ (void) setShouldPerformTestUserEmailCheckOnSignup:(BOOL)shouldPerform;
+
 - (void) signUpOnCompletion:(void (^)(NSError * error))completionBlock;
 - (void) signUpWithDataGroups:(NSArray<NSString *> *)dataGroups onCompletion:(void (^)(NSError *))completionBlock;
+
+/*
+ * @param vc -  a view controller that will be used to perform the test user check and display loading spinner
+ *              and also the prompt to the user to make sure they want to be test users
+ *              if kAPCUserBridgePerformTestUserEmailCheck is NO, method skips any testing
+ */
+- (void) signUpWithDataGroups:(NSArray<NSString *> *)dataGroups
+         withTestUserPromptVc:(__weak UIViewController*)vc
+                 onCompletion:(void (^)(NSError *))completionBlock;
+
 - (void) signInOnCompletion:(void (^)(NSError * error))completionBlock;
 - (void) signOutOnCompletion:(void (^)(NSError * error))completionBlock;
 - (void) updateDataGroups:(NSArray<NSString *> *)dataGroups onCompletion:(void (^)(NSError * error))completionBlock;

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.m
@@ -34,6 +34,12 @@
 #import "APCUser+Bridge.h"
 #import "APCAppCore.h"
 
+// If YES, sign up process will check for special string in email addresses to auto-detect test users
+// If NO, sign up will treat all emails and data as valid in production
+static BOOL shouldPerformTestUserEmailCheckOnSignup = NO;
+static NSString* const kHiddenTestEmailString = @"+test";
+static NSString* const kTestDataGroup = @"test_user";
+
 @implementation APCUser (Bridge)
 
 - (BOOL) serverDisabled
@@ -43,6 +49,11 @@
 #else
     return ((APCAppDelegate*)[UIApplication sharedApplication].delegate).dataSubstrate.parameters.bypassServer;
 #endif
+}
+
++ (void) setShouldPerformTestUserEmailCheckOnSignup:(BOOL)shouldPerform
+{
+    shouldPerformTestUserEmailCheckOnSignup = shouldPerform;
 }
 
 - (void)signUpOnCompletion:(void (^)(NSError *))completionBlock
@@ -78,6 +89,44 @@
                  }
              });
          }];
+    }
+}
+
+- (void) signUpWithDataGroups:(NSArray<NSString *> *)dataGroups
+         withTestUserPromptVc:(__weak UIViewController*)vc
+                 onCompletion:(void (^)(NSError *))completionBlock
+{
+    [self signUpWithDataGroups:dataGroups
+          withTestUserPromptVc:vc
+              includeTestCheck:shouldPerformTestUserEmailCheckOnSignup
+                verifiedTester:NO
+                  onCompletion:completionBlock];
+}
+
+- (void) signUpWithDataGroups:(NSArray<NSString *> *)dataGroups
+         withTestUserPromptVc:(__weak UIViewController*)vc
+             includeTestCheck:(BOOL)includeTestCheck
+               verifiedTester:(BOOL)userVerifiedAsTester
+                 onCompletion:(void (^)(NSError *))completionBlock
+{
+    if (!includeTestCheck ||
+        ![[self.email lowercaseString] containsString:kHiddenTestEmailString])
+    {
+        [self signUpWithDataGroups:dataGroups onCompletion:completionBlock];
+        return;
+    }
+    
+    if (!userVerifiedAsTester)
+    {
+        [self showTestUserVerificationAlertWithDataGroups:dataGroups
+                                     withTestUserPromptVc:vc
+                                             onCompletion:completionBlock];
+    }
+    else
+    {
+        NSMutableArray* dataGroupsWithTest = [dataGroups mutableCopy];
+        [dataGroupsWithTest addObject:kTestDataGroup];
+        [self signUpWithDataGroups:dataGroupsWithTest onCompletion:completionBlock];
     }
 }
 
@@ -566,6 +615,63 @@
              });
          }];
     }
+}
+
+/*********************************************************************************/
+#pragma mark - UI Methods
+/*********************************************************************************/
+
+- (void) showTestUserVerificationAlertWithDataGroups:(NSArray<NSString *> *)dataGroups
+                                withTestUserPromptVc:(__weak UIViewController*)vc
+                                        onCompletion:(void (^)(NSError *))completionBlock
+{
+    UIViewController* previousPresentedVc = vc.presentedViewController;
+    [vc dismissViewControllerAnimated:YES completion:^{
+        NSString* yesStr = NSLocalizedString(@"YES", @"Positive Answer");
+        NSString* noStr =  NSLocalizedString(@"NO", @"Negative Answer");
+        NSString* title =  NSLocalizedString(@"Are you a tester?", @"Question if the user is a quality assurance tester");
+        NSString* msg = [NSString stringWithFormat:NSLocalizedString(@"Based on your email address, we have detected you are a tester for %@.  If this is correct, select %@ so we can store your data separately.", @"Message informing user if and what happens if they are a tester"), [APCUtilities appName], [yesStr lowercaseString]];
+        
+        UIAlertController* alert = [UIAlertController alertControllerWithTitle:title
+                                                                       message:msg
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        
+        UIAlertAction* noAction = [UIAlertAction actionWithTitle:noStr
+                                                           style:UIAlertActionStyleDefault
+                                                         handler:^(__unused UIAlertAction * _Nonnull action)
+       {
+           [self signUpWithDataGroups:dataGroups
+                 withTestUserPromptVc:vc
+                     includeTestCheck:NO
+                       verifiedTester:NO
+                         onCompletion:completionBlock];
+           
+           if (previousPresentedVc != nil)
+           {
+               [vc presentViewController:previousPresentedVc animated:YES completion:nil];
+           }
+       }];
+        [alert addAction:noAction];
+        
+        UIAlertAction* yesAction = [UIAlertAction actionWithTitle:yesStr
+                                                            style:UIAlertActionStyleDefault
+                                                          handler:^(__unused UIAlertAction * _Nonnull action)
+        {
+            [self signUpWithDataGroups:dataGroups
+                  withTestUserPromptVc:vc
+                      includeTestCheck:YES
+                        verifiedTester:YES
+                          onCompletion:completionBlock];
+            
+            if (previousPresentedVc != nil)
+            {
+                [vc presentViewController:previousPresentedVc animated:YES completion:nil];
+            }
+        }];
+        [alert addAction:yesAction];
+        
+        [vc presentViewController:alert animated:alert completion:nil];
+    }];
 }
 
 /*********************************************************************************/

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.m
@@ -626,52 +626,75 @@ static NSString* const kTestDataGroup = @"test_user";
                                         onCompletion:(void (^)(NSError *))completionBlock
 {
     UIViewController* previousPresentedVc = vc.presentedViewController;
-    [vc dismissViewControllerAnimated:YES completion:^{
-        NSString* yesStr = NSLocalizedString(@"YES", @"Positive Answer");
-        NSString* noStr =  NSLocalizedString(@"NO", @"Negative Answer");
-        NSString* title =  NSLocalizedString(@"Are you a tester?", @"Question if the user is a quality assurance tester");
-        NSString* msg = [NSString stringWithFormat:NSLocalizedString(@"Based on your email address, we have detected you are a tester for %@.  If this is correct, select %@ so we can store your data separately.", @"Message informing user if and what happens if they are a tester"), [APCUtilities appName], [yesStr lowercaseString]];
-        
-        UIAlertController* alert = [UIAlertController alertControllerWithTitle:title
-                                                                       message:msg
-                                                                preferredStyle:UIAlertControllerStyleAlert];
-        
-        UIAlertAction* noAction = [UIAlertAction actionWithTitle:noStr
-                                                           style:UIAlertActionStyleDefault
-                                                         handler:^(__unused UIAlertAction * _Nonnull action)
-       {
-           [self signUpWithDataGroups:dataGroups
-                 withTestUserPromptVc:vc
-                     includeTestCheck:NO
-                       verifiedTester:NO
-                         onCompletion:completionBlock];
-           
-           if (previousPresentedVc != nil)
-           {
-               [vc presentViewController:previousPresentedVc animated:YES completion:nil];
-           }
-       }];
-        [alert addAction:noAction];
-        
-        UIAlertAction* yesAction = [UIAlertAction actionWithTitle:yesStr
-                                                            style:UIAlertActionStyleDefault
-                                                          handler:^(__unused UIAlertAction * _Nonnull action)
+    
+    if (previousPresentedVc != nil)
+    {
+        [vc dismissViewControllerAnimated:YES completion:^
         {
-            [self signUpWithDataGroups:dataGroups
-                  withTestUserPromptVc:vc
-                      includeTestCheck:YES
-                        verifiedTester:YES
-                          onCompletion:completionBlock];
-            
-            if (previousPresentedVc != nil)
-            {
-                [vc presentViewController:previousPresentedVc animated:YES completion:nil];
-            }
+            [self showTestUserVerificationAlertWithDataGroups:dataGroups
+                                         withTestUserPromptVc:vc
+                                                 onCompletion:completionBlock
+                                          previousPresentedVc:previousPresentedVc];
         }];
-        [alert addAction:yesAction];
-        
-        [vc presentViewController:alert animated:alert completion:nil];
-    }];
+    }
+    else
+    {
+        [self showTestUserVerificationAlertWithDataGroups:dataGroups
+                                     withTestUserPromptVc:vc
+                                             onCompletion:completionBlock
+                                      previousPresentedVc:previousPresentedVc];
+    }
+}
+
+- (void) showTestUserVerificationAlertWithDataGroups:(NSArray<NSString *> *)dataGroups
+                                withTestUserPromptVc:(__weak UIViewController*)vc
+                                        onCompletion:(void (^)(NSError *))completionBlock
+                                 previousPresentedVc:(UIViewController*)previousPresentedVc
+{
+    NSString* yesStr = NSLocalizedString(@"YES", @"Positive Answer");
+    NSString* noStr =  NSLocalizedString(@"NO", @"Negative Answer");
+    NSString* title =  NSLocalizedString(@"Are you a tester?", @"Question if the user is a quality assurance tester");
+    NSString* msg = [NSString stringWithFormat:NSLocalizedString(@"Based on your email address, we have detected you are a tester for %@.  If this is correct, select %@ so we can store your data separately.", @"Message informing user if and what happens if they are a tester"), [APCUtilities appName], [yesStr lowercaseString]];
+    
+    UIAlertController* alert = [UIAlertController alertControllerWithTitle:title
+                                                                   message:msg
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction* noAction = [UIAlertAction actionWithTitle:noStr
+                                                       style:UIAlertActionStyleDefault
+                                                     handler:^(__unused UIAlertAction * _Nonnull action)
+                               {
+                                   [self signUpWithDataGroups:dataGroups
+                                         withTestUserPromptVc:vc
+                                             includeTestCheck:NO
+                                               verifiedTester:NO
+                                                 onCompletion:completionBlock];
+                                   
+                                   if (previousPresentedVc != nil)
+                                   {
+                                       [vc presentViewController:previousPresentedVc animated:YES completion:nil];
+                                   }
+                               }];
+    [alert addAction:noAction];
+    
+    UIAlertAction* yesAction = [UIAlertAction actionWithTitle:yesStr
+                                                        style:UIAlertActionStyleDefault
+                                                      handler:^(__unused UIAlertAction * _Nonnull action)
+                                {
+                                    [self signUpWithDataGroups:dataGroups
+                                          withTestUserPromptVc:vc
+                                              includeTestCheck:YES
+                                                verifiedTester:YES
+                                                  onCompletion:completionBlock];
+                                    
+                                    if (previousPresentedVc != nil)
+                                    {
+                                        [vc presentViewController:previousPresentedVc animated:YES completion:nil];
+                                    }
+                                }];
+    [alert addAction:yesAction];
+    
+    [vc presentViewController:alert animated:alert completion:nil];
 }
 
 /*********************************************************************************/


### PR DESCRIPTION
Per Erin and I's conversation, here is the test user feature added to app core.  

The feature defaults to disabled; however, to turn it on simply call,

`[APCUser setShouldPerformTestUserEmailCheckOnSignup:YES];`

and then also pass it your `UIViewController` to the signUp method.

This will automatically prompt the user with the verify dialog if it detects a "+test" in the email, and will add "test_user" to the data groups if the user selects yes, if they select no, it will add them as a regular user still.  This dialog will properly dismiss any previously showing loading dialog, and represent it after the user has interacted with the dialog.
