### PR TITLE
APCShare okayTapped conditional ordering

### DIFF
--- a/APCAppCore/APCAppCore/UI/Onboarding/APCShareViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCShareViewController.m
@@ -307,12 +307,11 @@
 
 - (IBAction) okayTapped: (id) __unused sender
 {
-    if (self.taskViewController != nil) {
+    if (self.goBackIfUserHitsOkay) {
+        [self back];
+    } else if (self.taskViewController != nil) {
         // If this is a step view controller then dismiss
         [self goForward];
-    }
-    else if (self.goBackIfUserHitsOkay) {
-        [self back];
     } else {
         [self.navigationController popToRootViewControllerAnimated:YES];
     }


### PR DESCRIPTION
Check "goBackIfUserHitsOkay" first. If that's true, it should take precedence over whether or not its a taskViewController as its a direct definition of what pressing "Okay" should do.

Existing implementations are either or as far as I'm aware, but order should still be right. Noticed this while investigating another issue.
