### PR TITLE
bug/BRIDGE-905

### DIFF
--- a/APCAppCore/APCAppCore/UI/Components/APCBadgeLabel.h
+++ b/APCAppCore/APCAppCore/UI/Components/APCBadgeLabel.h
@@ -35,8 +35,6 @@
 
 @interface APCBadgeLabel : UILabel
 
-@property (nonatomic, strong) UIColor *tintColor;
-
 @property (nonatomic) CGFloat lineWidth;
 
 @end

--- a/APCAppCore/APCAppCore/UI/Components/APCBadgeLabel.m
+++ b/APCAppCore/APCAppCore/UI/Components/APCBadgeLabel.m
@@ -92,4 +92,11 @@
     [self setNeedsDisplay];
 }
 
+- (void) setTintColor:(UIColor *)tintColor
+{
+    _tintColor = tintColor;
+    self.textColor = tintColor;
+    self.layer.borderColor  = self.tintColor.CGColor;
+}
+
 @end

--- a/APCAppCore/APCAppCore/UI/Components/APCBadgeLabel.m
+++ b/APCAppCore/APCAppCore/UI/Components/APCBadgeLabel.m
@@ -60,7 +60,7 @@
 
 - (void)sharedInit
 {
-    _tintColor = [UIColor appPrimaryColor];
+    self.tintColor = [UIColor appPrimaryColor];
     
     _lineWidth = 1.0f;
     
@@ -92,10 +92,9 @@
     [self setNeedsDisplay];
 }
 
-- (void) setTintColor:(UIColor *)tintColor
+- (void) tintColorDidChange
 {
-    _tintColor = tintColor;
-    self.textColor = tintColor;
+    self.textColor = self.tintColor;
     self.layer.borderColor  = self.tintColor.CGColor;
 }
 


### PR DESCRIPTION
Fixed tint color property on APCBadgeLabel to properly update.

Per Story:
This can be tested pretty easily by signing up, getting the tasks, then setting your iPhone's date to about 20 hours in the future, then going back into the app and scrolling the tableview up and down. before I fixed the bug, the red and grey colors would swap between cells, now they all stay the correct color.
