### PR TITLE
Bug/bridge 1175

### DIFF
--- a/APCAppCore/APCAppCore/Library/APCTaskImporter.m
+++ b/APCAppCore/APCAppCore/Library/APCTaskImporter.m
@@ -213,11 +213,12 @@ static NSArray *legalTimeSpecifierFormats = nil;
         
         // TODO: This logic can be simplified once daysBehind is an option - we no longer have to worry about deleting
         // "Yesterday" tasks.
-        // Check that the activity was not finished - if it was, we don't want to remove it (since Bridge stops returning it)
+        // (%K < %@) Select this as one of the tasks that was not updated
+        // (%K == nil) Check that the activity was not finished - if it was, we don't want to remove it (since Bridge stops returning it)
         // Check that the activity was not a "yesterday" task, by confirming it:
-            // Had no expiration OR
-            // Expired before yesterday OR
-            // Expired today or later
+            // %K.length == 0 Had no expiration OR
+            // %K < %@ Expired before yesterday OR
+            // %K > %@ Expired today or later
         NSPredicate *findObsoleteTasks = [NSPredicate predicateWithFormat:
                                           @"(%K < %@) && (%K == nil) && (%K.length == 0 OR %K < %@ OR %K > %@)",
                                           NSStringFromSelector (@selector (updatedAt)),           // -[APCTask taskScheduledFor]

--- a/APCAppCore/APCAppCore/Library/APCTaskImporter.m
+++ b/APCAppCore/APCAppCore/Library/APCTaskImporter.m
@@ -221,13 +221,13 @@ static NSArray *legalTimeSpecifierFormats = nil;
             // %K > %@ Expired today or later
         NSPredicate *findObsoleteTasks = [NSPredicate predicateWithFormat:
                                           @"(%K < %@) && (%K == nil) && (%K.length == 0 OR %K < %@ OR %K > %@)",
-                                          NSStringFromSelector (@selector (updatedAt)),           // -[APCTask taskScheduledFor]
+                                          NSStringFromSelector (@selector (updatedAt)),           // -[APCTask updatedAt]
                                           fiveMinutesAgo,
-                                          NSStringFromSelector (@selector (taskFinished)),           // -[APCTask taskExpires]
+                                          NSStringFromSelector (@selector (taskFinished)),           // -[APCTask taskFinished]
                                           NSStringFromSelector (@selector (taskExpires)),           // -[APCTask taskExpires]
                                           NSStringFromSelector (@selector (taskExpires)),           // -[APCTask taskExpires]
                                           midnightYesterdayMorning,
-                                          NSStringFromSelector (@selector (taskExpires)),           // -[APCTask taskFinished]
+                                          NSStringFromSelector (@selector (taskExpires)),           // -[APCTask taskExpires]
                                           midnightThisMorning
                                           ];
         NSFetchRequest *obsoleteTaskRequest = [APCTask requestWithPredicate: findObsoleteTasks];


### PR DESCRIPTION
The core issue w/ 1175 is tasks sticking around even after the schedule changed and showing up in the task list despite no longer being valid.

The simple solution is just to clear cached tasks every time. However, Bridge currently does not return 2 types of results that we still want to display in the app:

1) Completed activities
2) Expired incomplete activities from the day before (shows up in the yesterday section)

So if we just clear the cache every time, then whenever they complete something and refresh from bridge the task disappears and their completion % goes back to 0. In addition, they would never see a yesterday's tasks section.

This PR addresses this by waiting until after the import is complete and saved. Then, it deletes anything that wasn't updated by the import (aka everything that DIDN'T come down from latest bridge fetch) with the exception of the two categories listed above.
