### PR TITLE
feature/FPHS-583

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.h
@@ -110,6 +110,9 @@ typedef NS_ENUM(NSInteger, APCUserConsentSharingScope) {
 @property (nonatomic) HKBiologicalSex biologicalSex;
 @property (nonatomic) HKBloodType bloodType;
 
+// @return YES if birthdate property comes from healthkit, NO if comes from core data
+- (BOOL) hasBirthDateInHealthKit;
+- (BOOL) hasBiologicalSexInHealthKit;
 
 @property (nonatomic, strong, nullable) HKQuantity * height;
 @property (nonatomic, strong, nullable) HKQuantity * weight;

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.m
@@ -528,6 +528,14 @@ static NSString *const kSignedInKey = @"SignedIn";
     [self updateStoredProperty:kBirthDatePropertyName withValue:birthDate];
 }
 
+- (BOOL) hasBirthDateInHealthKit
+{
+    NSError *error;
+    NSDate *dateOfBirth = [self.healthStore dateOfBirthWithError:&error];
+    APCLogError2 (error);
+    return dateOfBirth != nil;
+}
+
 - (HKBiologicalSex)biologicalSex
 {
     NSError *error;
@@ -540,6 +548,14 @@ static NSString *const kSignedInKey = @"SignedIn";
 {
     _biologicalSex = biologicalSex;
     [self updateStoredProperty:kBiologicalSexPropertyName withValue:@(biologicalSex)];
+}
+
+- (BOOL) hasBiologicalSexInHealthKit
+{
+    NSError *error;
+    HKBiologicalSexObject * sexObject = [self.healthStore biologicalSexWithError:&error];
+    APCLogError2 (error);
+    return sexObject.biologicalSex != HKBiologicalSexNotSet;
 }
 
 - (HKBloodType)bloodType

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
@@ -73,7 +73,16 @@
 
 @property (nonatomic, strong) UIImage *profileImage;
 
+/*
+ * If set to YES, birthdate will be a Date Picker Cell, and can be edited when isEditing is also set to YES
+ * If set to NO, birthdate will be a Default Cell, with its value locked no matter what
+ */
 @property (nonatomic) BOOL canEditBirthDate;
+
+/*
+ * If set to YES, biological sex will be a Segment Cell, and can be edited when isEditing is also set to YES
+ * If set to NO, biological sex will be a Default Cell, with its value locked no matter what
+ */
 @property (nonatomic) BOOL canEditBiologicalSex;
 
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
@@ -37,7 +37,7 @@
 
 @protocol APCProfileViewControllerDelegate;
 
-@interface APCProfileViewController : APCUserInfoViewController <APCPickerTableViewCellDelegate, APCTextFieldTableViewCellDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate,UITextFieldDelegate, APCSwitchTableViewCellDelegate>
+@interface APCProfileViewController : APCUserInfoViewController <APCPickerTableViewCellDelegate, APCTextFieldTableViewCellDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate,UITextFieldDelegate, APCSwitchTableViewCellDelegate, APCSegmentedTableViewCellDelegate>
 
 @property (nonatomic, strong) APCUser *user;
 
@@ -72,6 +72,9 @@
 @property (nonatomic, weak) id <APCProfileViewControllerDelegate> delegate;
 
 @property (nonatomic, strong) UIImage *profileImage;
+
+@property (nonatomic) BOOL canEditBirthDate;
+@property (nonatomic) BOOL canEditBiologicalSex;
 
 
 - (IBAction)leaveStudy:(id)sender;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
@@ -123,4 +123,13 @@
 - (void)hasStartedEditing;
 
 - (void)hasFinishedEditing;
+
+/*
+ * If canEditBirthDate or canEditBiologicalSex are set to YES,
+ * This will be called if the user tries to edit either of them when we are
+ * loading them from HealthKit, but writing to HealthKit is not valid
+ * Dev should launch a dialog when this is called saying to change in the Health App
+ */
+- (void) editingFailedForHealthKitType:(NSString*) healthKitIdentifier;
+
 @end

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -1211,27 +1211,33 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                 
             case kAPCUserInfoItemTypeDateOfBirth:
             {
-                if (self.canEditBirthDate &&
-                    ![self isEditingAllowedForHealthKitProperty:HKCharacteristicTypeIdentifierDateOfBirth])
+                if (self.canEditBirthDate)
                 {
-                    [self showEditingNotAllowedAlertForHealthKitProperty:HKCharacteristicTypeIdentifierDateOfBirth];
-                    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+                    APCTableViewItem *field = [self itemForIndexPath:indexPath];
+                    // Check for if we grabbed this value from HealthKit, because if we did, it can't be edited from our app
+                    if (![self isEditingAllowedForHealthKitProperty:HKCharacteristicTypeIdentifierDateOfBirth])
+                    {
+                        [self showEditingNotAllowedAlertForHealthKitProperty:HKCharacteristicTypeIdentifierDateOfBirth];
+                        [tableView deselectRowAtIndexPath:indexPath animated:YES];
+                    }
+                    // only allow to be selected if we are in edit mode
+                    else if (self.isEditing && field.isEditable)
+                    {
+                        [super tableView:tableView didSelectRowAtIndexPath:indexPath];
+                    }
+                    // if we cant edit it, simply deselect the row
+                    else
+                    {
+                        [tableView deselectRowAtIndexPath:indexPath animated:YES];
+                    }
                 }
                 else
                 {
-                    APCTableViewItem *field = [self itemForIndexPath:indexPath];
-                    if (self.isEditing && field.isEditable) {
-                        [super tableView:tableView didSelectRowAtIndexPath:indexPath];
-                    }
+                    [super tableView:tableView didSelectRowAtIndexPath:indexPath];
                 }
             }
                 break;
-                
-            case kAPCUserInfoItemTypeHeight:
-            {
-                [self setEditing:!self.isEditing];
-            }
-            
+
             default:{
                 [super tableView:tableView didSelectRowAtIndexPath:indexPath];
             }

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -448,7 +448,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     for (UITableViewCell* cell in visibleCells) {
         
         // Segment control cells do not respond to didSelectRowAtIndex,
-        // So we need to change the editable property
+        // So we need to change the editable property here, instead of blocking it in didSelectRowAtIndex
         if ([cell isKindOfClass:[APCSegmentedTableViewCell class]])
         {
             NSIndexPath* indexPath = [self.tableView indexPathForCell:cell];


### PR DESCRIPTION
In FPHS, have been getting complaints/feedback that the user's birthdate and biological sex are not editable from the profile screen.

So, I made a property in the APCProfileViewController that you can toggle on those fields being editable; however, they are still off by default so they will be backwards compatible.

When on, the birthdate is a date picker and the biological sex is a segment button.

What complicated this issue a bit more is that we cannot edit biological sex or birthdate in health kit programmatically, so in the case where we can edit, but we are using Health Kit for the values, I added an alert informing the user to change the property in the Health App.
