### PR TITLE
FPHS 562

### DIFF
--- a/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.h
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.h
@@ -41,6 +41,7 @@ FOUNDATION_EXPORT NSString * kAPCAccountAlreadyExistsErrorMessage;
 FOUNDATION_EXPORT NSString * kAPCAccountDoesNotExistErrorMessage;
 FOUNDATION_EXPORT NSString * kAPCBadEmailAddressErrorMessage;
 FOUNDATION_EXPORT NSString * kAPCBadPasswordErrorMessage;
+FOUNDATION_EXPORT NSString * kAPCBadPasswordWithDetailsErrorMessage;
 FOUNDATION_EXPORT NSString * kAPCNotReachableErrorMessage;
 FOUNDATION_EXPORT NSString * kAPCInvalidEmailAddressOrPasswordErrorMessage;
 

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+APCAdditions.m
@@ -43,6 +43,7 @@ NSString * kAPCAccountAlreadyExistsErrorMessage;
 NSString * kAPCAccountDoesNotExistErrorMessage;
 NSString * kAPCBadEmailAddressErrorMessage;
 NSString * kAPCBadPasswordErrorMessage;
+NSString * kAPCBadPasswordWithDetailsErrorMessage;
 NSString * kAPCNotReachableErrorMessage;
 NSString * kAPCInvalidEmailAddressOrPasswordErrorMessage;
 
@@ -61,6 +62,7 @@ static NSString * const oneTab = @"    ";
     kAPCAccountDoesNotExistErrorMessage            = NSLocalizedStringWithDefaultValue(@"There is no account registered for this email address and password combination.", @"APCAppCore", APCBundle(), @"There is no account registered for this email address and password combination.", @"Error message when participant attempts to sign in to an existing account with an incorrect email address or password");
     kAPCBadEmailAddressErrorMessage                = NSLocalizedStringWithDefaultValue(@"The email address submitted is not a valid email address. Please correct the email address and try again.", @"APCAppCore", APCBundle(), @"The email address submitted is not a valid email address. Please correct the email address and try again.", @"Error message when participant attempts to sign up using a non-valid email address");
     kAPCBadPasswordErrorMessage                    = NSLocalizedStringWithDefaultValue(@"The password you have entered is not a valid password.  Please try again.", @"APCAppCore", APCBundle(), @"The password you have entered is not a valid password.  Please try again.", @"Error message when participant attempts to sign up with a non-valid password");
+    kAPCBadPasswordWithDetailsErrorMessage         = NSLocalizedStringWithDefaultValue(@"The password you have entered is not a valid password.  Please try again. Details: %@", @"APCAppCore", APCBundle(), @"The password you have entered is not a valid password.  Please try again. Details: %@", @"Format for error message when participant attempts to sign up with a non-valid password, to be filled in with specifics of why it's not valid from the server error message");
     kAPCNotReachableErrorMessage                   = NSLocalizedStringWithDefaultValue(@"We are currently not able to reach the study server. Please retry in a few moments.", @"APCAppCore", APCBundle(), @"We are currently not able to reach the study server. Please retry in a few moments.", @"Error message when the app is unable to reach the Bridge server");
     kAPCInvalidEmailAddressOrPasswordErrorMessage  = NSLocalizedStringWithDefaultValue(@"Entered email address or password is not valid. Please correct the email address or password and try again.", @"APCAppCore", APCBundle(), @"Entered email address or password is not valid. Please correct the email address or password and try again.", @"Error message when participant attempts to sign up with a non-valid email address or password");
 }

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
@@ -87,7 +87,13 @@ static NSString *kSageInvalidUsernameOrPassword  = @"Invalid username or passwor
 		}
 		else if([errors valueForKey: kSageErrorPasswordKey])
 		{
-			message = kAPCBadPasswordErrorMessage;
+            NSArray *passwordErrors = [errors valueForKey: kSageErrorPasswordKey];
+            NSString *errorsString = [passwordErrors componentsJoinedByString:@", "];
+            if (errorsString.length > 0) {
+                message = [NSString stringWithFormat:@"%@ Details: %@", kAPCBadPasswordErrorMessage, errorsString];
+            } else {
+                message = kAPCBadPasswordErrorMessage;
+            }
 		} else
 		{
 			message = kAPCInvalidEmailAddressOrPasswordErrorMessage;

--- a/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
+++ b/APCAppCore/APCAppCore/Library/Categories/NSError+Bridge.m
@@ -90,7 +90,7 @@ static NSString *kSageInvalidUsernameOrPassword  = @"Invalid username or passwor
             NSArray *passwordErrors = [errors valueForKey: kSageErrorPasswordKey];
             NSString *errorsString = [passwordErrors componentsJoinedByString:@", "];
             if (errorsString.length > 0) {
-                message = [NSString stringWithFormat:@"%@ Details: %@", kAPCBadPasswordErrorMessage, errorsString];
+                message = [NSString stringWithFormat:kAPCBadPasswordWithDetailsErrorMessage, errorsString];
             } else {
                 message = kAPCBadPasswordErrorMessage;
             }


### PR DESCRIPTION
Add details of password failure to message rather than forcing the user to guess. When PW requirements were added to FPHS, it resulted in many user complaints about inability to register. The server provides the details on why a password wasn't acceptable, so lets pass that on to the user to avoid confusion.
