### PR TITLE
FPHS 625

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.h
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.h
@@ -58,7 +58,6 @@ typedef NS_ENUM(NSInteger, APCUserConsentSharingScope) {
 
 @property (nonatomic, strong, nullable) NSString * firstName DEPRECATED_ATTRIBUTE;
 @property (nonatomic, strong, nullable) NSString * lastName DEPRECATED_ATTRIBUTE;
-
 @property (nonatomic, strong, nullable) NSString * email;
 @property (nonatomic, strong, nullable) NSString * password;
 @property (nonatomic, strong, nullable) NSString * sessionToken;
@@ -98,9 +97,6 @@ typedef NS_ENUM(NSInteger, APCUserConsentSharingScope) {
 @property (nonatomic, strong, nullable) NSDate *consentSignatureDate;
 @property (nonatomic, strong, nullable) NSData *consentSignatureImage;
 
-@property (nonatomic, strong, nullable) NSDate *downloadDataStartDate; // NOT stored in CoreData
-@property (nonatomic, strong, nullable) NSDate *downloadDataEndDate; // NOT stored in CoreData
-
 @property (nonatomic, getter=isSecondaryInfoSaved) BOOL secondaryInfoSaved;
 
 /*********************************************************************************/
@@ -125,6 +121,14 @@ typedef NS_ENUM(NSInteger, APCUserConsentSharingScope) {
 @property (nonatomic, getter=isSignedIn) BOOL signedIn;
 @property (nonatomic, nullable) NSNumber * savedSharingScope;
 @property (nonatomic, nullable) NSArray <NSString *> * dataGroups;
+
+/*********************************************************************************/
+#pragma mark - Stored In Memory Only
+/*********************************************************************************/
+@property (nonatomic, strong, nullable) NSString * cachedSessionToken; // Memory Only, can nil this out and sessionToken will remain safely in keychain
+@property (nonatomic, strong, nullable) NSDate *downloadDataStartDate; // NOT stored in CoreData
+@property (nonatomic, strong, nullable) NSDate *downloadDataEndDate; // NOT stored in CoreData
+
 
 - (BOOL) isLoggedOut;
 

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser.m
@@ -275,6 +275,20 @@ static NSString *const kSignedInKey = @"SignedIn";
     [APCKeychainStore setString:[self hashIfNeeded:password] forKey:kPasswordPropertyName];
 }
 
+- (NSString *)sessionToken
+{
+    if (self.cachedSessionToken == nil) {
+        self.cachedSessionToken = [APCKeychainStore stringForKey:kSessionTokenPropertyName];
+    }
+    return self.cachedSessionToken;
+}
+
+-(void)setSessionToken:(NSString *)sessionToken
+{
+    self.cachedSessionToken = sessionToken;
+    [APCKeychainStore setString:[self hashIfNeeded:sessionToken] forKey:kSessionTokenPropertyName];
+}
+
 - (NSString *)externalId
 {
     return [APCKeychainStore stringForKey:kExternalIdPropertyName];

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -273,7 +273,8 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
         [[NSUserDefaults standardUserDefaults] setObject: [NSNumber numberWithLong:uptime()] forKey:kLastUsedTimeKey];
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
-    self.dataSubstrate.currentUser.sessionToken = nil;
+    // Clear the in memory token while preserving the keychain version
+    self.dataSubstrate.currentUser.cachedSessionToken = nil;
     
     [self showSecureView];
 }


### PR DESCRIPTION
Previously the sessionToken was stored in memory only and never in the keychain. This makes sense from a performance perspective, but causes issues when it is cleared when the app is backgrounded (or terminated/crashes/whatever). Upon reopening, there is a potential race condition between the app trying to sign back in (and thus recreating the sessionToken) and the app asking for new activities. If the user makes it to the activities vc before the former finishes, the token won't exist yet and they'll see a not authenticated alert.

This attempts to remedy that by adding a cached in memory version for general usage but still storing it in the keychain for when the app is backgrounded/etc.
