### PR TITLE
bug/null_string_display

### DIFF
--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -152,7 +152,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     else {
         self.nameTextField.delegate = self;
         
-        self.nameTextField.text = self.user.name;
+        self.nameTextField.text = (self.user.name != nil) ? self.user.name : @"";
         self.nameTextField.enabled = NO;
         
         self.emailTextField.text = self.user.email;


### PR DESCRIPTION
The name can become nil if the user logs in on a fresh install without signing up.  We are looking into adding a name screen on log in for that case, but this helps mitigate the bug. So display blank string instead of <null>.
