### PR TITLE
feature/edit_users_name

### DIFF
--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.h
@@ -85,6 +85,12 @@
  */
 @property (nonatomic) BOOL canEditBiologicalSex;
 
+/*
+ * If set to YES, name text field can be edited by the user when isEditing 
+ * If set to NO, name will not be enabled
+ */
+@property (nonatomic) BOOL canEditUsersName;
+
 
 - (IBAction)leaveStudy:(id)sender;
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -153,7 +153,7 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
         self.nameTextField.delegate = self;
         
         self.nameTextField.text = (self.user.name != nil) ? self.user.name : @"";
-        self.nameTextField.enabled = NO;
+        self.nameTextField.enabled = self.canEditUsersName;
         
         self.emailTextField.text = self.user.email;
         self.emailTextField.enabled = NO;


### PR DESCRIPTION
Made users name editable.  This makes it easy for the user to re-enter their name, in the situation where they never signed up on a particular device, but only signed in.
