### PR TITLE
FPHS 687/Bridge 1394

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask+Bridge.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCTask+Bridge.m
@@ -112,7 +112,6 @@
             {
                 SBBSurvey * sbbSurvey = (SBBSurvey*) survey;
                 [self.managedObjectContext performBlockAndWait:^{
-                    self.taskTitle = sbbSurvey.name;
                     self.taskVersionName = sbbSurvey.guid;
                     self.taskVersionDate = sbbSurvey.createdOn;
                     self.taskSchemaRevision = sbbSurvey.schemaRevision;


### PR DESCRIPTION
Don't overwrite task title with the survey name, use activity.label from activity instead.
