### PR TITLE
FPHS 673

### DIFF
--- a/APCAppCore/APCAppCore/Consent/APCConsentTask.m
+++ b/APCAppCore/APCAppCore/Consent/APCConsentTask.m
@@ -202,6 +202,7 @@ static NSString*    kStepIdentifierSuffixStart          = @"+X";
                                                                                 inDocument:_consentDocument];
     
     reviewStep.reasonForConsent = reason;
+    reviewStep.title = NSLocalizedStringWithDefaultValue(@"Name", @"APCAppCore", APCBundle(), @"Name", nil); // Title of page where it asks for first and last name
     
     NSMutableArray* consentSteps = [[NSMutableArray alloc] init];
     [consentSteps addObject:_visualStep];

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -116,6 +116,9 @@
     
     APCCheckTableViewCell *cell = (APCCheckTableViewCell *)[tableView dequeueReusableCellWithIdentifier:kAPCCheckTableViewCellIdentifier];
     
+    cell.textLabel.minimumScaleFactor = 0.5f;
+    cell.textLabel.adjustsFontSizeToFitWidth = YES; // no ellipses
+    
     cell.textLabel.text = optionItem.caption;
     cell.confirmationView.completed = optionItem.on;
     


### PR DESCRIPTION
Default the title for the name screen to Name instead of a Consent which is a confusing duplicate
See https://sagebionetworks.jira.com/browse/FPHS-673 for bug and screenshot

(current default of "Consent" in RK seems strange)
