### PR TITLE
bug/FPHS-670

### DIFF
--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
@@ -151,6 +151,7 @@ extern NSString *const kNewsFeedStoryBoardKey;
  * Otherwise, post a "APCUserForgotPasscodeNotification" notification and the alert will be shown for you
  */
 - (void) resetAppAndProceedToSignIn;
+- (void) resetAppAndProceedToOnboarding;
 
 - (void) clearPreviousUserData;
 

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -758,13 +758,12 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     [self.tasksReminder updateTasksReminder];
 }
 
-- (void) logOutAndGoToSignIn
+- (void)logoutData
 {
     self.dataSubstrate.currentUser.signedUp = NO;
     self.dataSubstrate.currentUser.signedIn = NO;
     [APCKeychainStore removeValueForKey:kPasswordKey];
     [self.tasksReminder updateTasksReminder];
-    [self showOnBoardingAndThenSignIn];
 }
 
 - (void) showOnBoardingAndThenSignIn
@@ -1240,7 +1239,21 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
 
 #pragma mark - Reset Methods
 
+- (void) resetAppAndProceedToOnboarding
+{
+    [self clearUserInfo];
+    [self logoutData];
+    [self showOnBoarding];
+}
+
 - (void) resetAppAndProceedToSignIn
+{
+    [self clearUserInfo];
+    [self logoutData];
+    [self showOnBoardingAndThenSignIn];
+}
+
+- (void) clearUserInfo
 {
     APCAppDelegate * appDelegate = (APCAppDelegate*) [UIApplication sharedApplication].delegate;
     UIViewController * vc =  [[UIViewController alloc] init];
@@ -1250,8 +1263,6 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     // This is all that is needed to force the re-registration of the PIN
     APCUser* user = [((id<APCOnboardingManagerProvider>)appDelegate) onboardingManager].user;
     user.secondaryInfoSaved = NO;
-    
-    [self logOutAndGoToSignIn];
 }
 
 - (void) clearPreviousUserData

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -269,12 +269,17 @@
         }
         else {
             [spinnerController dismissViewControllerAnimated:NO completion:^{
-                APCWithdrawCompleteViewController *viewController = [[UIStoryboard storyboardWithName:@"APCProfile" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWithdrawCompleteViewController"];
-                UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:viewController];
-                [weakSelf.navigationController presentViewController:navController animated:YES completion:nil];
+                [weakSelf showWithdrawCompleteViewController];
             }];
         }
     }];
+}
+
+- (void) showWithdrawCompleteViewController
+{
+    APCWithdrawCompleteViewController *viewController = [[UIStoryboard storyboardWithName:@"APCProfile" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWithdrawCompleteViewController"];
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:viewController];
+    [self.navigationController presentViewController:navController animated:YES completion:nil];
 }
 
 - (IBAction)cancel:(id) __unused sender


### PR DESCRIPTION
I added the resetAppAndProceedToOnboarding for after user withdraws.  It is the same as resetAppAndProceedToSignIn except it doesn't go to the sign in.  I had to re-organize some methods, but no logic changed.  I tested both methods and they still are backwards compatible.

I also pushed the logic showWithdrawCompleteViewController to its own method so that sub-classes could control where the next screen goes.
