### PR TITLE
bug/FPHS-729

### DIFF
--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.h
@@ -44,6 +44,8 @@
 
 @property (weak, nonatomic) IBOutlet UIButton *submitButton;
 
+@property (nonatomic) BOOL allowUserToDeselectCustomOpt;
+
 @property (nonatomic, strong) NSArray *items;
 
 - (NSArray *)prepareContent;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.h
@@ -44,8 +44,6 @@
 
 @property (weak, nonatomic) IBOutlet UIButton *submitButton;
 
-@property (nonatomic) BOOL allowUserToDeselectCustomOpt;
-
 @property (nonatomic, strong) NSArray *items;
 
 - (NSArray *)prepareContent;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -61,6 +61,7 @@
     
     self.items = [self prepareContent];
     self.descriptionText = @"";
+    self.allowUserToDeselectCustomOpt = YES;
     
     self.submitButton.enabled = NO;
     

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -61,7 +61,6 @@
     
     self.items = [self prepareContent];
     self.descriptionText = @"";
-    self.allowUserToDeselectCustomOpt = YES;
     
     self.submitButton.enabled = NO;
     
@@ -132,7 +131,7 @@
         
         APCTableViewSwitchItem *optionItem = [self itemForIndexPath:indexPath];
         
-        if (optionItem.on == NO || self.allowUserToDeselectCustomOpt == NO) {
+        if (optionItem.on == NO) {
             APCWithdrawDescriptionViewController *viewController = [[UIStoryboard storyboardWithName:@"APCProfile" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWithdrawDescriptionViewController"];
             viewController.delegate = self;
             viewController.descriptionText = self.descriptionText;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCWithdrawSurveyViewController.m
@@ -129,12 +129,19 @@
     APCTableViewSection *sectionItem = self.items[indexPath.section];
     if ((NSUInteger)indexPath.row == (sectionItem.rows.count - 1)) {
         
-        APCWithdrawDescriptionViewController *viewController = [[UIStoryboard storyboardWithName:@"APCProfile" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWithdrawDescriptionViewController"];
-        viewController.delegate = self;
-        viewController.descriptionText = self.descriptionText;
-        UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:viewController];
-        [self.navigationController presentViewController:navController animated:YES completion:nil];
+        APCTableViewSwitchItem *optionItem = [self itemForIndexPath:indexPath];
         
+        if (optionItem.on == NO || self.allowUserToDeselectCustomOpt == NO) {
+            APCWithdrawDescriptionViewController *viewController = [[UIStoryboard storyboardWithName:@"APCProfile" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCWithdrawDescriptionViewController"];
+            viewController.delegate = self;
+            viewController.descriptionText = self.descriptionText;
+            UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:viewController];
+            [self.navigationController presentViewController:navController animated:YES completion:nil];
+        } else {
+            optionItem.on = !optionItem.on;
+            self.descriptionText = @"";
+            [tableView reloadData];
+        }        
     } else {
         APCTableViewSwitchItem *optionItem = [self itemForIndexPath:indexPath];
         optionItem.on = !optionItem.on;


### PR DESCRIPTION
Allow withdraw survey user entered reason to be de-selected if flag is set to YES. 

Defaulted behavior to YES so that user can deselect it, which fixes a bug that once it was selected you could never delete the text in the pop-up or uncheck it.

The two FPHS story references are:
https://sagebionetworks.jira.com/browse/FPHS-739
https://sagebionetworks.jira.com/browse/FPHS-729
