### PR TITLE
Slight hack to support endSurvey rules

### DIFF
--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCSmartSurveyTask.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCSmartSurveyTask.m
@@ -300,6 +300,11 @@ static APCDummyObject * _dummyObject;
     id value                = [rule valueForKeyPath:kRuleValueKey];
     NSString * skipToValue  = [rule valueForKeyPath:kRuleSkipToKey];
     
+    // emm 2016-12-07 hack to support endSurvey rules, which are the only ones that have no skipTo value
+    if (!skipToValue) {
+        skipToValue = kEndOfSurveyMarker;
+    }
+    
     //Skip
     if ([operator isEqualToString:kOperatorSkip] && answer == nil) {
         retValue = skipToValue;

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
@@ -565,8 +565,13 @@ static CGFloat const kTableViewSectionHeaderHeight = 77;
 {
     self.isFetchingFromCoreDataRightNow = YES;
     APCSpinnerViewController *spinnerController = [[APCSpinnerViewController alloc] init];
-    [self presentViewController:spinnerController animated:YES completion:nil];
+    [self presentViewController:spinnerController animated:YES completion:^{
+        [self actuallyReloadTasksFromCoreDataWithSpinnerController:spinnerController];
+    }];
+}
 
+- (void)actuallyReloadTasksFromCoreDataWithSpinnerController:(APCSpinnerViewController *)spinnerController
+{
     NSPredicate *filterForOptionalTasks = [NSPredicate predicateWithFormat: @"%K == %@",
                                            NSStringFromSelector(@selector(taskIsOptional)),
                                            @(YES)];
@@ -693,6 +698,11 @@ static CGFloat const kTableViewSectionHeaderHeight = 77;
              //
              weakSelf.isFetchingFromCoreDataRightNow = NO;
              [weakSelf updateWholeUI];
+             
+             // don't forget to dismiss the spinner!
+             dispatch_async(dispatch_get_main_queue(), ^{
+                 [spinnerController dismissViewControllerAnimated:YES completion:nil];
+             });
 
          }];  // second fetch:  optional tasks
      }];  // first fetch:  required tasks, for a range of dates


### PR DESCRIPTION
detect endSurvey rules based on missing skipTo field, and fill in “END_OF_SURVEY” as the skipTo identifier so existing AppCore logic around this will handle it.