### PR TITLE
Change result archiver to apply a date formatter to the ‘dateAnswer’ field

### DIFF
--- a/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCTaskResultArchiver.m
+++ b/APCAppCore/APCAppCore/Library/DataArchiverAndUploader/APCTaskResultArchiver.m
@@ -53,6 +53,7 @@ static NSString * const kStartDateKey               = @"startDate";
 static NSString * const kEndDateKey                 = @"endDate";
 static NSString * const kUserInfoKey                = @"userInfo";
 static NSString * const kAnswerKey                  = @"answer";
+static NSString * const kDateAnswerKey              = @"dateAnswer";
 
 //
 //    General-Use Dictionary Keys
@@ -382,7 +383,7 @@ static  NSString  *const  kSpatialSpanMemoryTouchSampleIsCorrectKey     = @"Memo
     // a specific date format per sage bridge documentation
     NSDictionary* dateFormatterForKeys = nil;
     if (result.questionType == ORKQuestionTypeDate) {
-        dateFormatterForKeys = @{ kAnswerKey: ORKResultDateFormatter() };
+        dateFormatterForKeys = @{ kAnswerKey: ORKResultDateFormatter(), kDateAnswerKey: ORKResultDateFormatter() };
     }
     
     NSDictionary *propertiesToSave = [result dictionaryWithValuesForKeys: propertyNames];


### PR DESCRIPTION
Bridge-1054: Changing result archiver to apply a date formatter to the ‘dateAnswer’ field, as it was already being applied to the ‘answer’ field.