### PR TITLE
Bridge 1659 - prompt user to continue doing activities

### DIFF
--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.h
@@ -126,6 +126,7 @@ extern NSString *const kNewsFeedStoryBoardKey;
 - (NSArray *)allSetTextBlocks;
 - (NSDictionary *)configureTasksForActivities;
 - (BOOL)hideEmailOnWelcomeScreen;
+- (BOOL)promptUserToContinueActivities;
 
 //To be called from Datasubstrate
 - (void) setUpCollectors;

--- a/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
+++ b/APCAppCore/APCAppCore/Startup/APCAppDelegate.m
@@ -646,6 +646,15 @@ static NSString*    const kAppWillEnterForegroundTimeKey    = @"APCWillEnterFore
     return NO;
 }
 
+- (BOOL)promptUserToContinueActivities
+{
+    /* Abstract implementation. Subclass to override.
+     *
+     * To show an alert to the user to continue activities after they complete an activity return YES.
+     */
+    return NO;
+}
+
 /*********************************************************************************/
 #pragma mark - Catastrophic startup errors
 /*********************************************************************************/

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Activities/APCActivitiesViewController.m
@@ -170,13 +170,11 @@ static NSString * const kAPCAlertMessageKeepGoing               = @"It is helpfu
                                                  name: UIApplicationDidBecomeActiveNotification
                                                object: nil];
     
-    if (self.appDelegate.promptUserToContinueActivities) {
-        // Upon completion of activity, check to see if we should show an alert encouraging user to continue
-        [[NSNotificationCenter defaultCenter] addObserver: self
-                                                 selector: @selector (handleActivityCompleteNotification)
-                                                     name: APCActivityCompletionNotification
-                                                   object: nil];
-    }
+    // Upon completion of activity, check to see if we should show an alert encouraging user to continue
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector (handleActivityCompleteNotification)
+                                                 name: APCActivityCompletionNotification
+                                               object: nil];
 }
 
 
@@ -252,7 +250,7 @@ static NSString * const kAPCAlertMessageKeepGoing               = @"It is helpfu
      So, we check to see if our remaining count is more than 1 (instead of more than 0).
      */
     
-    if (self.countOfRemainingTasksToday > 1) {
+    if (self.appDelegate.promptUserToContinueActivities && self.countOfRemainingTasksToday > 1) {
         
         // show an alert prompting them to continue doing activities. Delay so task
         // view controller has time to dismiss


### PR DESCRIPTION
Bridge-1659:
- Add abstract method to appDelegate for promptUserToContinueActivities, which will show an alert urging user to continue doing activities.
- Updates to APCActivitiesVC to listen for activity completed notification. Upon this notification, reload data and check if there are more activities to do for today. If so, prompt user to continue. If user continues, start the next activity that is not yet complete.
- Refactor a few methods: didSelectRow and viewControllerToShowForCellAtIndexPath
- Made a change to this class in it’s data loading behavior. It used to reload data every time upon viewWillAppear. Now, it loads data on viewDidLoad and upon notifications - activity complete notif and other notifs such as app entered foreground, app became active and APCDayChangeNotification