### PR TITLE
Bridge 1623a - Allow user to enter referral code

### DIFF
--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		031C95FD1E491B1D00DD34FE /* APCReferralCodeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 031C95FB1E491B1D00DD34FE /* APCReferralCodeViewController.m */; };
 		031C96001E491B3F00DD34FE /* APCAddReferralCodeViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 031C95FE1E491B3F00DD34FE /* APCAddReferralCodeViewController.h */; };
 		031C96011E491B3F00DD34FE /* APCAddReferralCodeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 031C95FF1E491B3F00DD34FE /* APCAddReferralCodeViewController.m */; };
+		03B697E51E4E5D10001AE2CA /* APCReferralCodeTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B697E31E4E5D10001AE2CA /* APCReferralCodeTextField.h */; };
+		03B697E61E4E5D10001AE2CA /* APCReferralCodeTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B697E41E4E5D10001AE2CA /* APCReferralCodeTextField.m */; };
 		049439811B8FC04000CAE23C /* APCDownloadDataViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0494397F1B8FC04000CAE23C /* APCDownloadDataViewController.h */; };
 		049439821B8FC04000CAE23C /* APCDownloadDataViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 049439801B8FC04000CAE23C /* APCDownloadDataViewController.m */; };
 		04FB64471BB4883900D0A50D /* APCTaskImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FB64451BB4883900D0A50D /* APCTaskImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -752,6 +754,8 @@
 		031C95FB1E491B1D00DD34FE /* APCReferralCodeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCReferralCodeViewController.m; sourceTree = "<group>"; };
 		031C95FE1E491B3F00DD34FE /* APCAddReferralCodeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCAddReferralCodeViewController.h; sourceTree = "<group>"; };
 		031C95FF1E491B3F00DD34FE /* APCAddReferralCodeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCAddReferralCodeViewController.m; sourceTree = "<group>"; };
+		03B697E31E4E5D10001AE2CA /* APCReferralCodeTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCReferralCodeTextField.h; sourceTree = "<group>"; };
+		03B697E41E4E5D10001AE2CA /* APCReferralCodeTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCReferralCodeTextField.m; sourceTree = "<group>"; };
 		045D0CBD1BBAFDC500330C7E /* APCModel 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "APCModel 8.xcdatamodel"; sourceTree = "<group>"; };
 		0494397F1B8FC04000CAE23C /* APCDownloadDataViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCDownloadDataViewController.h; sourceTree = "<group>"; };
 		049439801B8FC04000CAE23C /* APCDownloadDataViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = APCDownloadDataViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -2781,6 +2785,8 @@
 				F5F1294F1A2F78490015982C /* APCStudyOverviewViewController.m */,
 				031C95FA1E491B1D00DD34FE /* APCReferralCodeViewController.h */,
 				031C95FB1E491B1D00DD34FE /* APCReferralCodeViewController.m */,
+				03B697E31E4E5D10001AE2CA /* APCReferralCodeTextField.h */,
+				03B697E41E4E5D10001AE2CA /* APCReferralCodeTextField.m */,
 				F5F129501A2F78490015982C /* APCUserInfoConstants.h */,
 				F5F129511A2F78490015982C /* EmailVerification */,
 				F5F1295D1A2F78490015982C /* SignIn */,
@@ -3303,6 +3309,7 @@
 				F5B947E71A73272C0034C522 /* APCSegmentedButton.h in Headers */,
 				F5B947C71A73272C0034C522 /* NSObject+Helper.h in Headers */,
 				747307101A96E1DE0071D863 /* APCCMS.h in Headers */,
+				03B697E51E4E5D10001AE2CA /* APCReferralCodeTextField.h in Headers */,
 				7423AB5B1AA3FFD8004A325A /* APCConsentRedirector.h in Headers */,
 				081A477A1A93EC4700E13148 /* APCBadgeLabel.h in Headers */,
 				F5F12A891A2F78490015982C /* APCTableViewItem.h in Headers */,
@@ -3735,6 +3742,7 @@
 				F5F12AF71A2F78490015982C /* APCStepViewController.m in Sources */,
 				CFFDEDDB1A95734000B25581 /* APCFrequencyDayTableViewCell.m in Sources */,
 				F5F12AFE1A2F78490015982C /* APCIntroductionViewController.m in Sources */,
+				03B697E61E4E5D10001AE2CA /* APCReferralCodeTextField.m in Sources */,
 				F5F12ADD1A2F78490015982C /* APCSegmentedTableViewCell.m in Sources */,
 				F50738C11A682E12004CF100 /* APCDateRange.m in Sources */,
 				5B7D471D1B0549FA00958921 /* APCCubicCurveAlgorithm.m in Sources */,

--- a/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
+++ b/APCAppCore/APCAppCore.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		031C95FC1E491B1D00DD34FE /* APCReferralCodeViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 031C95FA1E491B1D00DD34FE /* APCReferralCodeViewController.h */; };
+		031C95FD1E491B1D00DD34FE /* APCReferralCodeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 031C95FB1E491B1D00DD34FE /* APCReferralCodeViewController.m */; };
+		031C96001E491B3F00DD34FE /* APCAddReferralCodeViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 031C95FE1E491B3F00DD34FE /* APCAddReferralCodeViewController.h */; };
+		031C96011E491B3F00DD34FE /* APCAddReferralCodeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 031C95FF1E491B3F00DD34FE /* APCAddReferralCodeViewController.m */; };
 		049439811B8FC04000CAE23C /* APCDownloadDataViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0494397F1B8FC04000CAE23C /* APCDownloadDataViewController.h */; };
 		049439821B8FC04000CAE23C /* APCDownloadDataViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 049439801B8FC04000CAE23C /* APCDownloadDataViewController.m */; };
 		04FB64471BB4883900D0A50D /* APCTaskImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 04FB64451BB4883900D0A50D /* APCTaskImporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -744,6 +748,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		031C95FA1E491B1D00DD34FE /* APCReferralCodeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCReferralCodeViewController.h; sourceTree = "<group>"; };
+		031C95FB1E491B1D00DD34FE /* APCReferralCodeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCReferralCodeViewController.m; sourceTree = "<group>"; };
+		031C95FE1E491B3F00DD34FE /* APCAddReferralCodeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCAddReferralCodeViewController.h; sourceTree = "<group>"; };
+		031C95FF1E491B3F00DD34FE /* APCAddReferralCodeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APCAddReferralCodeViewController.m; sourceTree = "<group>"; };
 		045D0CBD1BBAFDC500330C7E /* APCModel 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "APCModel 8.xcdatamodel"; sourceTree = "<group>"; };
 		0494397F1B8FC04000CAE23C /* APCDownloadDataViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APCDownloadDataViewController.h; sourceTree = "<group>"; };
 		049439801B8FC04000CAE23C /* APCDownloadDataViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = APCDownloadDataViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -2771,6 +2779,8 @@
 				F5F1294D1A2F78490015982C /* APCStudyDetailsViewController.m */,
 				F5F1294E1A2F78490015982C /* APCStudyOverviewViewController.h */,
 				F5F1294F1A2F78490015982C /* APCStudyOverviewViewController.m */,
+				031C95FA1E491B1D00DD34FE /* APCReferralCodeViewController.h */,
+				031C95FB1E491B1D00DD34FE /* APCReferralCodeViewController.m */,
 				F5F129501A2F78490015982C /* APCUserInfoConstants.h */,
 				F5F129511A2F78490015982C /* EmailVerification */,
 				F5F1295D1A2F78490015982C /* SignIn */,
@@ -2916,6 +2926,8 @@
 				5B09ED1E1ABC1BEF003C5061 /* APCLicenseInfoViewController.m */,
 				0494397F1B8FC04000CAE23C /* APCDownloadDataViewController.h */,
 				049439801B8FC04000CAE23C /* APCDownloadDataViewController.m */,
+				031C95FE1E491B3F00DD34FE /* APCAddReferralCodeViewController.h */,
+				031C95FF1E491B3F00DD34FE /* APCAddReferralCodeViewController.m */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -3228,6 +3240,7 @@
 				CFFDEDE01A95734000B25581 /* APCMedicationFrequencyViewController.h in Headers */,
 				7B6C8CBB1AA26ECE0007B560 /* APCConsentQuestion.h in Headers */,
 				5BD6EBB71A9C77D900C3BFB0 /* APCBaseGraphView.h in Headers */,
+				031C95FC1E491B1D00DD34FE /* APCReferralCodeViewController.h in Headers */,
 				F5F12B061A2F78490015982C /* APCUserInfoViewController.h in Headers */,
 				7B6C8CBF1AA26ECE0007B560 /* APCConsentTextChoiceQuestion.h in Headers */,
 				369C77931B1F9171007DD687 /* APCDataVerificationServerAccessControl.h in Headers */,
@@ -3342,6 +3355,7 @@
 				F5B9480A1A73272C0034C522 /* APCScheduleExpressionToken.h in Headers */,
 				F5F12AD01A2F78490015982C /* APCWithdrawSurveyViewController.h in Headers */,
 				368BAFE91A9AD91A00F04ABB /* APCMedTrackerDailyDosageRecord.h in Headers */,
+				031C96001E491B3F00DD34FE /* APCAddReferralCodeViewController.h in Headers */,
 				CBC2593A1C58077A0091308E /* MockAPCTasksReminderManager.h in Headers */,
 				F5B947F61A73272C0034C522 /* APCParametersDashboardTableViewController.h in Headers */,
 				F5F12AF21A2F78490015982C /* APCBaseTaskViewController.h in Headers */,
@@ -3755,6 +3769,7 @@
 				369E27F01A96B7A200D35DFA /* APCMedicationDataStorageEngine.m in Sources */,
 				369E27EE1A96B7A200D35DFA /* APCMedicationColor.m in Sources */,
 				CFFDEDE41A95734000B25581 /* APCColorSwatchTableViewCell.m in Sources */,
+				031C95FD1E491B1D00DD34FE /* APCReferralCodeViewController.m in Sources */,
 				7B8DBEC31AA186C4007B4026 /* APCHorizontalThinLineView.m in Sources */,
 				F5B947F91A73272C0034C522 /* APCParametersUserDefaultCell.m in Sources */,
 				F5F12AEF1A2F78490015982C /* APCDashboardPieGraphTableViewCell.m in Sources */,
@@ -3819,6 +3834,7 @@
 				F5B947CA1A73272C0034C522 /* NSString+Helper.m in Sources */,
 				369E28111A96B7A200D35DFA /* APCMedTrackerPossibleDosage+Helper.m in Sources */,
 				CF130B791A9E8DCD002DA023 /* APCSetupButtonTableViewCell.m in Sources */,
+				031C96011E491B3F00DD34FE /* APCAddReferralCodeViewController.m in Sources */,
 				CFFDED6F1A95731F00B25581 /* APCMedicationTrackerCalendarDailyView.m in Sources */,
 				7BEC13D51AA3AA5B00CA316C /* APCActivityTrackingStepViewController.m in Sources */,
 				F5B947AE1A73272C0034C522 /* APCAppearanceInfo.m in Sources */,

--- a/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.m
+++ b/APCAppCore/APCAppCore/DataSubstrate/Model/APCUser+Bridge.m
@@ -75,23 +75,23 @@ static NSString* const kBaseEmailAddressForExternalIdKey = @"baseEmailAddressFor
     {
         NSParameterAssert(self.email);
         NSParameterAssert(self.password);
-        [SBBComponent(SBBAuthManager) signUpWithEmail: self.email
-                                             username: self.email
-                                             password: self.password
-                                           dataGroups:dataGroups
-                                           completion: ^(NSURLSessionTask * __unused task,
-                                                         id __unused responseObject,
-                                                         NSError *error)
-         {
-             dispatch_async(dispatch_get_main_queue(), ^{
-                 if (!error) {
-                     APCLogEventWithData(kNetworkEvent, (@{@"event_detail":@"User Signed Up"}));
-                 }
-                 if (completionBlock) {
-                     completionBlock(error);
-                 }
-             });
-         }];
+        
+        SBBSignUp *signUp = [[SBBSignUp alloc] init];
+        signUp.email = self.email;
+        signUp.password = self.password;
+        signUp.dataGroups = [NSSet setWithArray:dataGroups];
+        signUp.externalId = self.externalId;
+        
+        [SBBComponent(SBBAuthManager) signUpStudyParticipant:signUp completion:^(NSURLSessionTask *task __unused, id responseObject __unused, NSError *error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (!error) {
+                    APCLogEventWithData(kNetworkEvent, (@{@"event_detail":@"User Signed Up"}));
+                }
+                if (completionBlock) {
+                    completionBlock(error);
+                }
+            });
+        }];
     }
 }
 

--- a/APCAppCore/APCAppCore/Library/AppearanceHelpers/APCAppearanceInfo.m
+++ b/APCAppCore/APCAppCore/Library/AppearanceHelpers/APCAppearanceInfo.m
@@ -72,7 +72,8 @@ static NSDictionary * localAppearanceDictionary;
              kTertiaryPurpleColorKey : [UIColor colorWithRed:0.574 green:0.252 blue:0.829 alpha:1.000],
              kTertiaryGrayColorKey : [UIColor colorWithRed:157/255.0f green:157/255.0f blue:157/255.0f alpha:1.000],
              kBorderLineColor: [UIColor colorWithWhite:0.749 alpha:1.000],
-             kPrimaryNavBarColorKey : [UIColor whiteColor]
+             kPrimaryNavBarColorKey : [UIColor whiteColor],
+             kCheckmarkGreenColorKey : [UIColor colorWithRed:77/255.0f green:217/255.0f blue:99/255.0f alpha:1.000]
              };
 }
 

--- a/APCAppCore/APCAppCore/Library/AppearanceHelpers/UIColor+APCAppearance.h
+++ b/APCAppCore/APCAppCore/Library/AppearanceHelpers/UIColor+APCAppearance.h
@@ -56,6 +56,8 @@
 + (UIColor *) appBorderLineColor;
 + (UIColor *) appPrimaryNavBarColor;
 
++ (UIColor *)checkmarkGreenColor;
+
 + (UIColor *)tertiaryColorForString:(NSString *)colorName;
 
 + (UIColor *)colorForTaskId:(NSString *)taskId;

--- a/APCAppCore/APCAppCore/Library/AppearanceHelpers/UIColor+APCAppearance.m
+++ b/APCAppCore/APCAppCore/Library/AppearanceHelpers/UIColor+APCAppearance.m
@@ -139,6 +139,11 @@
     return [APCAppearanceInfo valueForAppearanceKey:kPrimaryNavBarColorKey];
 }
 
++ (UIColor *)checkmarkGreenColor
+{
+    return [APCAppearanceInfo valueForAppearanceKey:kCheckmarkGreenColorKey];
+}
+
 + (UIColor *)colorForTaskId:(NSString *)taskId
 {
     return [APCAppearanceInfo valueForAppearanceKey:taskId];

--- a/APCAppCore/APCAppCore/Library/Categories/UIImage+APCHelper.h
+++ b/APCAppCore/APCAppCore/Library/Categories/UIImage+APCHelper.h
@@ -35,6 +35,7 @@
 
 @interface UIImage (APCHelper)
 + (UIImage *)imageWithColor:(UIColor *)color;
++ (UIImage *)colorImage:(UIImage *)source withColor:(UIColor *)color;
 
 - (UIImage *)flippedImage:(UIImageOrientation)orientation;
 

--- a/APCAppCore/APCAppCore/Library/Categories/UIImage+APCHelper.m
+++ b/APCAppCore/APCAppCore/Library/Categories/UIImage+APCHelper.m
@@ -50,6 +50,37 @@
     return image;
 }
 
++ (UIImage *)colorImage:(UIImage *)source withColor:(UIColor *)color{
+    
+    // begin a new image context, to draw our colored image onto with the right scale
+    UIGraphicsBeginImageContextWithOptions(source.size, NO, [UIScreen mainScreen].scale);
+    
+    // get a reference to that context we created
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    // set the fill color
+    [color setFill];
+    
+    // translate/flip the graphics context (for transforming from CG* coords to UI* coords
+    CGContextTranslateCTM(context, 0, source.size.height);
+    CGContextScaleCTM(context, 1.0, -1.0);
+    
+    CGContextSetBlendMode(context, kCGBlendModeColorBurn);
+    CGRect rect = CGRectMake(0, 0, source.size.width, source.size.height);
+    CGContextDrawImage(context, rect, source.CGImage);
+    
+    CGContextSetBlendMode(context, kCGBlendModeSourceIn);
+    CGContextAddRect(context, rect);
+    CGContextDrawPath(context,kCGPathFill);
+    
+    // generate a new UIImage from the graphics context we drew onto
+    UIImage *coloredImg = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    //return the color-burned image
+    return coloredImg;
+}
+
 - (UIImage *)flippedImage:(UIImageOrientation)orientation
 {
     if (self.images.count > 0)

--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.h
@@ -237,6 +237,8 @@ FOUNDATION_EXPORT NSString *const kTertiaryYellowColorKey;
 FOUNDATION_EXPORT NSString *const kTertiaryPurpleColorKey;
 FOUNDATION_EXPORT NSString *const kTertiaryGrayColorKey;
 
+FOUNDATION_EXPORT NSString *const kCheckmarkGreenColorKey;
+
 FOUNDATION_EXPORT NSString *const kBorderLineColor;
 FOUNDATION_EXPORT NSString *const kPrimaryNavBarColorKey;
 

--- a/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
+++ b/APCAppCore/APCAppCore/Library/Objects/APCConstants.m
@@ -222,6 +222,8 @@ NSString *const kTertiaryGrayColorKey   = @"TertiaryGrayColorKey";
 NSString *const kBorderLineColor        = @"LightGrayBorderColorKey";
 NSString *const kPrimaryNavBarColorKey  = @"PrimaryNavBarColorKey";
 
+NSString *const kCheckmarkGreenColorKey  = @"CheckmarkGreenColorKey";
+
 NSString *const kTasksReminderDefaultsOnOffKey = @"TasksReminderDefaultsOnOffKey";
 NSString *const kTasksReminderDefaultsTimeKey = @"TasksReminderDefaultsTimeKey";
 

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboarding.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboarding.m
@@ -103,6 +103,7 @@
     addScene(kAPCSignUpGeneralInfoStepIdentifier);
     addScene(kAPCSignUpMedicalInfoStepIdentifier);
     self.onboardingTask.customStepIncluded = addScene(kAPCSignUpCustomInfoStepIdentifier);
+    addScene(kAPCReferralCodeStepIdentifier);
     addScene(kAPCSignUpPasscodeStepIdentifier);
     addScene(kAPCSignUpPermissionsStepIdentifier);
     addScene(kAPCSignUpThankYouStepIdentifier);
@@ -183,6 +184,7 @@
     _onboardingTask.generalInfoStep = _scenes[kAPCSignUpGeneralInfoStepIdentifier].step;
     _onboardingTask.medicalInfoStep = _scenes[kAPCSignUpMedicalInfoStepIdentifier].step;
     _onboardingTask.customInfoStep = _scenes[kAPCSignUpCustomInfoStepIdentifier].step;
+    _onboardingTask.referralCodeStep = _scenes[kAPCReferralCodeStepIdentifier].step;
     _onboardingTask.passcodeStep = _scenes[kAPCSignUpPasscodeStepIdentifier].step;
     _onboardingTask.permissionsStep = _scenes[kAPCSignUpPermissionsStepIdentifier].step;
     _onboardingTask.thankyouStep = _scenes[kAPCSignUpThankYouStepIdentifier].step;

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingManager.m
@@ -197,6 +197,10 @@ NSString * const kAPCOnboardingStoryboardName = @"APCOnboarding";
     if ([type isEqualToString:kAPCSignUpShareAppStepIdentifier]) {
         return [[APCScene alloc] initWithName:@"APCShareViewController" inStoryboard:kAPCOnboardingStoryboardName];
     }
+
+    if ([type isEqualToString:kAPCReferralCodeStepIdentifier]) {
+        return [[APCScene alloc] initWithName:@"APCReferralCodeViewController" inStoryboard:kAPCOnboardingStoryboardName];
+    }
     
     // Sign In
     if ([type isEqualToString:kAPCSignInStepIdentifier]) {

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingTask.h
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingTask.h
@@ -54,6 +54,7 @@ FOUNDATION_EXPORT NSString *const kAPCSignUpThankYouStepIdentifier;
 FOUNDATION_EXPORT NSString *const kAPCSignInStepIdentifier;
 FOUNDATION_EXPORT NSString *const kAPCSignUpPermissionsPrimingStepIdentifier;
 FOUNDATION_EXPORT NSString *const kAPCSignUpShareAppStepIdentifier;
+FOUNDATION_EXPORT NSString *const kAPCReferralCodeStepIdentifier;
 
 @protocol APCOnboardingTaskDelegate;
 
@@ -89,6 +90,8 @@ FOUNDATION_EXPORT NSString *const kAPCSignUpShareAppStepIdentifier;
 @property (nonatomic, strong) ORKStep *medicalInfoStep;
 
 @property (nonatomic, strong) ORKStep *customInfoStep;
+
+@property (nonatomic, strong) ORKStep *referralCodeStep;
 
 @property (nonatomic, strong) ORKStep *passcodeStep;
 

--- a/APCAppCore/APCAppCore/UI/Model/APCOnboardingTask.m
+++ b/APCAppCore/APCAppCore/UI/Model/APCOnboardingTask.m
@@ -46,6 +46,7 @@ NSString *const kAPCSignUpThankYouStepIdentifier            = @"ThankYou";
 NSString *const kAPCSignInStepIdentifier                    = @"SignIn";
 NSString *const kAPCSignUpPermissionsPrimingStepIdentifier  = @"PermissionsPriming";
 NSString *const kAPCSignUpShareAppStepIdentifier            = @"ShareApp";
+NSString *const kAPCReferralCodeStepIdentifier              = @"ReferralCode";
 
 @implementation APCOnboardingTask
 
@@ -172,6 +173,15 @@ NSString *const kAPCSignUpShareAppStepIdentifier            = @"ShareApp";
     }
     
     return _customInfoStep;
+}
+
+- (ORKStep *)referralCodeStep
+{
+    if (!_referralCodeStep) {
+        _referralCodeStep = [[ORKStep alloc] initWithIdentifier:kAPCReferralCodeStepIdentifier];
+    }
+    
+    return _referralCodeStep;
 }
 
 - (ORKStep *)passcodeStep

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeTextField.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeTextField.h
@@ -13,24 +13,39 @@
 @protocol APCReferralCodeTextFieldDelegate <NSObject>
 
 @optional
+/*
+ Tell our delegate that the backspace key was hit so it can go to previous textField.
+ This is necessary because there are no other standard UITextField delegate methods called
+ when backspace key is hit and the textField is empty
+ */
 - (void)APCReferralCodeTextFieldDidBackspace:(APCReferralCodeTextField*)textField;
 @end
 
-@interface HTTextField : UITextField<UIKeyInput>
-
-@property (nonatomic, assign) id<APCReferralCodeTextFieldDelegate> backspaceDelegate;
-
-@end
-
-
-@interface APCReferralCodeTextField : UITextField
+@interface APCReferralCodeTextField : UITextField<UIKeyInput>
 
 @property (nonatomic, assign)   id<APCReferralCodeTextFieldDelegate> referallCodeTextFieldDelegate;
 @property (nonatomic, copy)     NSString *regexString;
+
+/*
+ Track pending text changes on the textField since the textField contents are evaluated
+ before the textField is updated with the pending changes
+ */
 @property (nonatomic, copy)     NSString *pendingText;
+
 @property (assign)              NSUInteger numChars;
+
+/*
+ This will check current content against our regex string
+ */
 @property (readonly)            BOOL isValid;
+
+/*
+ This will determine which field the user can tap on the begin editing. We don't want them
+ to tap on field that are already filled in, for instance, so our delegate controls that by
+ setting this flag
+ */
 @property (assign)              BOOL isActive;
+
 @property (assign)              BOOL isEmpty;
 
 - (BOOL)isValidWithString:(NSString*)string;

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeTextField.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeTextField.h
@@ -1,0 +1,38 @@
+//
+//  APCReferralCodeTextField.h
+//  APCAppCore
+//
+//  Created by Josh Bruhin on 2/10/17.
+//  Copyright © 2017 Apple, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class APCReferralCodeTextField;
+
+@protocol APCReferralCodeTextFieldDelegate <NSObject>
+
+@optional
+- (void)APCReferralCodeTextFieldDidBackspace:(APCReferralCodeTextField*)textField;
+@end
+
+@interface HTTextField : UITextField<UIKeyInput>
+
+@property (nonatomic, assign) id<APCReferralCodeTextFieldDelegate> backspaceDelegate;
+
+@end
+
+
+@interface APCReferralCodeTextField : UITextField
+
+@property (nonatomic, assign)   id<APCReferralCodeTextFieldDelegate> referallCodeTextFieldDelegate;
+@property (nonatomic, copy)     NSString *regexString;
+@property (nonatomic, copy)     NSString *pendingText;
+@property (assign)              NSUInteger numChars;
+@property (readonly)            BOOL isValid;
+@property (assign)              BOOL isActive;
+@property (assign)              BOOL isEmpty;
+
+- (BOOL)isValidWithString:(NSString*)string;
+
+@end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeTextField.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeTextField.m
@@ -1,0 +1,31 @@
+//
+//  APCReferralCodeTextField.m
+//  APCAppCore
+//
+//  Created by Josh Bruhin on 2/10/17.
+//  Copyright © 2017 Apple, Inc. All rights reserved.
+//
+
+#import "APCReferralCodeTextField.h"
+
+@implementation APCReferralCodeTextField
+
+- (BOOL)isValid {
+    NSString *text = self.pendingText ? self.pendingText : self.text;
+    NSPredicate *test = [NSPredicate predicateWithFormat:@"%@ MATCHES %@", text, self.regexString];
+    return [test evaluateWithObject:self];
+}
+- (BOOL)isValidWithString:(NSString *)string {
+    NSPredicate *test = [NSPredicate predicateWithFormat:@"%@ MATCHES %@", string, self.regexString];
+    return [test evaluateWithObject:self];
+}
+
+- (void)deleteBackward {
+    [super deleteBackward];
+    if ([self.referallCodeTextFieldDelegate respondsToSelector:@selector(APCReferralCodeTextFieldDidBackspace:)]){
+        [self.referallCodeTextFieldDelegate APCReferralCodeTextFieldDidBackspace:self];
+    }
+}
+
+
+@end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.h
@@ -7,18 +7,19 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "APCFormTextField.h"
 #import "APCUser.h"
+#import "APCReferralCodeTextField.h"
 
-@interface APCReferralCodeViewController : UIViewController <UITextFieldDelegate, APCFormTextFieldDelegate>
+@interface APCReferralCodeViewController : UIViewController <UITextFieldDelegate, APCReferralCodeTextFieldDelegate>
 
-@property (weak, nonatomic) IBOutlet APCFormTextField *textField;
 @property (assign, nonatomic) UIBarButtonItem *saveButton;
+@property (strong, nonatomic) NSArray *textFields;
+@property (weak, nonatomic) IBOutlet UIView *textFieldContainView;
 
 // abstract methods
 - (void)setupSaveButton;
 - (IBAction)saveHit:(id)sender;
 - (APCUser *)currentUser;
-- (void)textFieldTextDidChangeTo:(NSString*)text;
+- (void)updateControls;
 
 @end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.h
@@ -9,6 +9,7 @@
 #import <UIKit/UIKit.h>
 #import "APCUser.h"
 #import "APCReferralCodeTextField.h"
+#import "APCSpinnerViewController.h"
 
 @interface APCReferralCodeViewController : UIViewController <UITextFieldDelegate, APCReferralCodeTextFieldDelegate>
 
@@ -21,5 +22,6 @@
 - (IBAction)saveHit:(id)sender;
 - (APCUser *)currentUser;
 - (void)updateControls;
+- (void)saveSucceededWithSpinnerController:(APCSpinnerViewController*)spinnerController;
 
 @end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.h
@@ -1,0 +1,24 @@
+//
+//  APCReferralCodeViewController.h
+//  APCAppCore
+//
+//  Created by Josh Bruhin on 2/6/17.
+//  Copyright © 2017 Apple, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "APCFormTextField.h"
+#import "APCUser.h"
+
+@interface APCReferralCodeViewController : UIViewController <UITextFieldDelegate, APCFormTextFieldDelegate>
+
+@property (weak, nonatomic) IBOutlet APCFormTextField *textField;
+@property (assign, nonatomic) UIBarButtonItem *saveButton;
+
+// abstract methods
+- (void)setupSaveButton;
+- (IBAction)saveHit:(id)sender;
+- (APCUser *)currentUser;
+- (void)textFieldTextDidChangeTo:(NSString*)text;
+
+@end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.m
@@ -1,0 +1,176 @@
+//
+//  APCReferralCodeViewController.m
+//  APCAppCore
+//
+//  Created by Josh Bruhin on 2/6/17.
+//  Copyright © 2017 Apple, Inc. All rights reserved.
+//
+
+#import "APCReferralCodeViewController.h"
+#import "APCUser.h"
+#import "APCContainerStepViewController.h"
+#import "APCOnboardingManager.h"
+#import "APCLocalization.h"
+#import "APCUserInfoConstants.h"
+#import "UIColor+APCAppearance.h"
+#import "NSString+Helper.h"
+#import "UIColor+APCAppearance.h"
+#import "UIFont+APCAppearance.h"
+
+@interface APCReferralCodeViewController ()
+
+@end
+
+@implementation APCReferralCodeViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    
+    [self setupTextField];
+    [self setupAppearance];
+    [self setupSaveButton];
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (APCContainerStepViewController *)parentStepViewController {
+    if ([self.parentViewController isKindOfClass:[APCContainerStepViewController class]]) {
+        return (APCContainerStepViewController*)self.parentViewController;
+    }
+    return nil;
+}
+
+
+- (APCOnboardingManager *)onboardingManager {
+    return [(id<APCOnboardingManagerProvider>)[UIApplication sharedApplication].delegate onboardingManager];
+}
+
+- (APCOnboarding *)onboarding {
+    return [self onboardingManager].onboarding;
+}
+
+#pragma mark - Setup
+
+- (void)setupAppearance {
+    [self.textField setTextColor:[UIColor appSecondaryColor1]];
+    [self.textField setFont:[UIFont appRegularFontWithSize:16.0f]];
+}
+
+- (void)setupTextField {
+    
+    self.textField.validationDelegate = self;
+    
+    //Set Default Values
+    self.textField.text = [self currentUser].externalId;
+    [self textFieldTextDidChangeTo:self.textField.text];
+}
+
+
+#pragma mark - Abstract classes
+
+- (void)setupSaveButton {
+    UIBarButtonItem *nextBarButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Next", @"APCAppCore", APCBundle(), @"Next", @"")
+                                                                      style:UIBarButtonItemStylePlain
+                                                                     target:self
+                                                                     action:@selector(saveHit:)];
+    self.saveButton = nextBarButton;
+}
+
+- (APCUser *)currentUser {
+    return [[self onboardingManager] userForOnboardingTask:[self parentStepViewController].taskViewController.task];
+}
+
+- (void)setSaveButton:(UIBarButtonItem *)saveButton {
+    [self parentStepViewController].navigationItem.rightBarButtonItem = saveButton;
+}
+- (UIBarButtonItem*)saveButton {
+    return [self parentStepViewController].navigationItem.rightBarButtonItem;
+}
+
+
+#pragma mark - Form validation
+
+- (void)textFieldTextDidChangeTo:(NSString*)text
+{
+    //    [UIView animateWithDuration:0.3 animations:^{
+    //        self.alertLabel.alpha = 0;
+    //    }];
+    
+    BOOL valid = [self refCodeIsValid:text];
+    self.textField.valid = valid;
+    
+    // if the textfield is empty, we don't want to show the invalid icon, so
+    // optionally hide the text fields validate button
+    self.textField.validationButton.hidden = text.length == 0;
+    
+    // enable the next button if the textField has no text or is valid
+    self.saveButton.enabled = valid || text.length == 0;
+}
+
+- (BOOL)refCodeIsValid:(NSString*)refCode
+{
+    BOOL fieldValid = NO;
+    
+    if (refCode > 0) {
+        fieldValid = [refCode isValidForRegex:kAPCUserInfoFieldReferralCodeRegEx];
+        
+        //        if (errorMessage && !fieldValid) {
+        //            errorMessage = NSLocalizedStringWithDefaultValue(@"Please enter a valid referral code.", @"APCAppCore", APCBundle(), @"Please enter a valid referral code.", @"");
+        //        }
+    } else {
+        //        if (errorMessage && !fieldValid) {
+        //            errorMessage = NSLocalizedStringWithDefaultValue(@"Referral code cannot be left empty.", @"APCAppCore", APCBundle(), @"Referral code cannot be left empty.", @"");
+        //        }
+    }
+    
+    
+    return fieldValid;
+}
+
+#pragma mark - Actions
+
+- (IBAction)saveHit:(id __unused)sender {
+    
+    [self.textField resignFirstResponder];
+    APCUser *currentUser = [self currentUser];
+    currentUser.externalId = self.textField.text;
+    
+    
+    [self goForward];
+}
+
+- (void)goForward {
+    if (self.parentStepViewController != nil) {
+        // If this has a step view controller parent then call goForward on the parent
+        [self.parentStepViewController goForward];
+    }
+    else {
+        // Otherwise, this uses APCOnboarding to handle navigation
+        UIViewController *viewController = [[self onboarding] nextScene];
+        [self.navigationController pushViewController:viewController animated:YES];
+    }
+}
+
+
+#pragma mark - UITextField delegate
+
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+    
+    NSString *text = [textField.text stringByReplacingCharactersInRange:range withString:string];
+    [self textFieldTextDidChangeTo:text];
+    
+    return YES;
+}
+
+#pragma mark - APCFormTextField delegate
+
+- (void)formTextFieldDidTapValidButton:(APCFormTextField *)textField
+{
+    [self textFieldTextDidChangeTo:textField.text];
+}
+
+@end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCReferralCodeViewController.m
@@ -90,10 +90,6 @@ static const NSUInteger kErrorCodeReferralCodeAlreadyUsed = 409;
 - (void)setupTextFields {
     
     // Iterate our model and create text fields and delimiter labels
-    // Also populate the text fields with current values, if any
-    
-    NSString *existingCode = [self currentUser].externalId;
-    NSArray *existingCodeFields = [existingCode componentsSeparatedByString:[kTextFieldDelimiterString copy]];
     
     UIView *previousView = nil;
     NSArray *textFieldDicts = [self textFieldDefinitions];
@@ -115,13 +111,6 @@ static const NSUInteger kErrorCodeReferralCodeAlreadyUsed = 409;
         textField.keyboardType = UIKeyboardTypeNumberPad;
         textField.delegate = self;
         textField.translatesAutoresizingMaskIntoConstraints = NO;
-        
-        if (existingCodeFields && existingCodeFields.count > i) {
-            NSString *fieldStr = existingCodeFields[i];
-            if (fieldStr && [textField isValidWithString:fieldStr]) {
-                textField.text = existingCodeFields[i];
-            }
-        }
         
         [textFields addObject:textField];
                 

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.h
@@ -38,7 +38,14 @@
 @property (nonatomic, weak) IBOutlet UIView *activityIndicatorContainerView;
 
 @property (nonatomic, weak) IBOutlet UIActivityIndicatorView *activityIndicatorView;
+@property (weak, nonatomic) IBOutlet UIImageView *checkmarkImageView;
 
 @property (nonatomic) BOOL landscape;
+
+/*
+ Call to replace activity indicator view with a checkmark and change background
+ color from black to green, then dismiss the view controller after a brief delay
+ */
+- (void)showCheckmarkThenDismissCompletion:(void (^ __nullable)(void))completion;
 
 @end

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.m
@@ -35,6 +35,7 @@
 #import "APCLog.h"
 #import "UIColor+APCAppearance.h"
 #import "NSBundle+Helper.h"
+#import "UIImage+APCHelper.h"
 
 
 @implementation APCSpinnerViewController
@@ -76,6 +77,36 @@
     [super viewDidDisappear:animated];
     
     [self.activityIndicatorView stopAnimating];
+}
+
+- (void)showCheckmarkThenDismissCompletion:(void (^ __nullable)(void))completion {
+
+    [self showCheckmark];
+    [self performSelector:@selector(dismissCompletion:) withObject:completion afterDelay:1.5];
+}
+
+- (void)showCheckmark {
+    
+    UIImage *image = [UIImage imageNamed:@"Completion-Check"];
+    self.checkmarkImageView.image = image;
+    self.checkmarkImageView.alpha = 0.0;
+    self.checkmarkImageView.hidden = NO;
+    
+    [UIView animateWithDuration:0.15 animations:^{
+
+        self.activityIndicatorContainerView.backgroundColor = [UIColor checkmarkGreenColor];
+        self.activityIndicatorView.alpha = 0.0;
+        self.checkmarkImageView.alpha = 1.0;
+    
+    } completion:^(BOOL finished __unused) {
+        
+        [self.activityIndicatorView stopAnimating];
+        [self.activityIndicatorView removeFromSuperview];
+    }];
+}
+
+- (void)dismissCompletion:(void (^ __nullable)(void))completion {
+    [self.presentingViewController dismissViewControllerAnimated:NO completion:completion];
 }
 
 #pragma mark - Orientation methods

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.m
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.m
@@ -94,7 +94,6 @@
     
     [UIView animateWithDuration:0.15 animations:^{
 
-        self.activityIndicatorContainerView.backgroundColor = [UIColor checkmarkGreenColor];
         self.activityIndicatorView.alpha = 0.0;
         self.checkmarkImageView.alpha = 1.0;
     

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.xib
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.xib
@@ -1,14 +1,19 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11760" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11755"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="APCSpinnerViewController">
             <connections>
                 <outlet property="activityIndicatorContainerView" destination="eUf-UI-a0C" id="iOM-Iw-5yr"/>
                 <outlet property="activityIndicatorView" destination="NfA-AC-doT" id="g1r-EP-WeH"/>
+                <outlet property="checkmarkImageView" destination="hcy-8v-pz5" id="RXm-6x-xbu"/>
                 <outlet property="view" destination="iN0-l3-epB" id="LGY-eJ-w2g"/>
             </connections>
         </placeholder>
@@ -22,15 +27,13 @@
                     <subviews>
                         <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="NfA-AC-doT">
                             <rect key="frame" x="32" y="31" width="37" height="37"/>
-                            <animations/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="37" id="3B8-pg-acY"/>
                                 <constraint firstAttribute="height" constant="37" id="stN-Fv-cvS"/>
                             </constraints>
                         </activityIndicatorView>
                     </subviews>
-                    <animations/>
-                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="centerX" secondItem="NfA-AC-doT" secondAttribute="centerX" constant="-0.5" id="2mF-xU-vcK"/>
                         <constraint firstAttribute="width" constant="100" id="7Xu-O9-f3G"/>
@@ -38,15 +41,25 @@
                         <constraint firstAttribute="height" constant="100" id="nuf-Fm-rlg"/>
                     </constraints>
                 </view>
+                <imageView hidden="YES" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="Completion-Check" translatesAutoresizingMaskIntoConstraints="NO" id="hcy-8v-pz5">
+                    <rect key="frame" x="116" y="240" width="88" height="88"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="88" id="DUY-9J-z3Q"/>
+                        <constraint firstAttribute="width" constant="88" id="Pf4-wa-Ye6"/>
+                    </constraints>
+                </imageView>
             </subviews>
-            <animations/>
-            <color key="tintColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+            <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="hcy-8v-pz5" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="2bn-hx-LWb"/>
                 <constraint firstAttribute="centerY" secondItem="eUf-UI-a0C" secondAttribute="centerY" id="Gh7-pZ-pC3"/>
+                <constraint firstItem="hcy-8v-pz5" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="K8Y-p5-7ci"/>
                 <constraint firstAttribute="centerX" secondItem="eUf-UI-a0C" secondAttribute="centerX" id="bWa-Dt-opu"/>
             </constraints>
-            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
             <point key="canvasLocation" x="355" y="366"/>
         </view>
     </objects>
+    <resources>
+        <image name="Completion-Check" width="88" height="88"/>
+    </resources>
 </document>

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.xib
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCSpinnerViewController.xib
@@ -41,11 +41,11 @@
                         <constraint firstAttribute="height" constant="100" id="nuf-Fm-rlg"/>
                     </constraints>
                 </view>
-                <imageView hidden="YES" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="Completion-Check" translatesAutoresizingMaskIntoConstraints="NO" id="hcy-8v-pz5">
-                    <rect key="frame" x="116" y="240" width="88" height="88"/>
+                <imageView hidden="YES" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" image="Completion-Check" translatesAutoresizingMaskIntoConstraints="NO" id="hcy-8v-pz5">
+                    <rect key="frame" x="141.5" y="265.5" width="37" height="37"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="88" id="DUY-9J-z3Q"/>
-                        <constraint firstAttribute="width" constant="88" id="Pf4-wa-Ye6"/>
+                        <constraint firstAttribute="height" constant="37" id="DUY-9J-z3Q"/>
+                        <constraint firstAttribute="width" constant="37" id="Pf4-wa-Ye6"/>
                     </constraints>
                 </imageView>
             </subviews>

--- a/APCAppCore/APCAppCore/UI/Onboarding/APCUserInfoConstants.h
+++ b/APCAppCore/APCAppCore/UI/Onboarding/APCUserInfoConstants.h
@@ -64,7 +64,8 @@ typedef NS_ENUM(APCTableViewItemType, APCUserInfoItemType) {
     kAPCSettingsItemTypePrivacyPolicy,
     kAPCSettingsItemTypeLicenseInformation,
     kAPCSettingsItemTypeSharingOptions,
-    kAPCSettingsItemTypeDownloadData
+    kAPCSettingsItemTypeDownloadData,
+    kAPCSettingsItemTypeReferralCode
 };
 
 
@@ -102,6 +103,7 @@ static NSString * const kAPCMedicalInfoItemWeightRegEx          = @"[0-9]{1,4}";
 
 static NSString * const kAPCMedicalInfoItemSleepTimeFormat     = @"hh:mm a";
 
+static NSString * const kAPCUserInfoFieldReferralCodeRegEx     = @"[A-Za-z]{3}+_[A-Za-z]{4}";
 
 static NSString * const kAPCAppStateKey = @"APCAppState";
 

--- a/APCAppCore/APCAppCore/UI/Onboarding/Base.lproj/APCOnboarding.storyboard
+++ b/APCAppCore/APCAppCore/UI/Onboarding/Base.lproj/APCOnboarding.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11760" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11755"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -750,7 +750,7 @@
                         <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="separatorColor" red="0.85098039219999999" green="0.85098039219999999" blue="0.85098039219999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <view key="tableHeaderView" contentMode="scaleToFill" id="Vgc-dS-iY6">
-                            <rect key="frame" x="0.0" y="64" width="375" height="256"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="256"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HY5-da-KSX">
@@ -841,7 +841,7 @@
                             </constraints>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="lnS-1T-Hjt">
-                            <rect key="frame" x="0.0" y="701" width="375" height="145"/>
+                            <rect key="frame" x="0.0" y="637" width="375" height="145"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lgU-Hg-9zH">
@@ -1057,12 +1057,12 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <view key="tableHeaderView" contentMode="scaleToFill" id="ZIh-IA-yZZ">
-                            <rect key="frame" x="0.0" y="64" width="375" height="32"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="32"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="LM9-U6-Md6">
-                            <rect key="frame" x="0.0" y="224" width="375" height="50"/>
+                            <rect key="frame" x="0.0" y="160" width="375" height="50"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o0E-mU-oFG">
@@ -1200,7 +1200,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <view key="tableHeaderView" contentMode="scaleToFill" id="JrT-2J-nDb">
-                            <rect key="frame" x="0.0" y="64" width="375" height="59"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="59"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Enter your email address in order to reset your Password." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6xa-7v-RVb">
@@ -1219,7 +1219,7 @@
                             </constraints>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="1Os-Uh-v3B">
-                            <rect key="frame" x="0.0" y="188" width="375" height="100"/>
+                            <rect key="frame" x="0.0" y="124" width="375" height="100"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Email messages" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IXV-QN-OmM">
@@ -1330,7 +1330,7 @@
                         <color key="separatorColor" red="0.85098039219999999" green="0.85098039219999999" blue="0.85098039219999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="gV4-YU-vnP" customClass="APCNavigationFooter">
-                            <rect key="frame" x="0.0" y="380" width="375" height="84"/>
+                            <rect key="frame" x="0.0" y="316" width="375" height="84"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
@@ -1557,7 +1557,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="4oe-zK-vQ9" customClass="APCNavigationFooter">
-                            <rect key="frame" x="0.0" y="286" width="375" height="84"/>
+                            <rect key="frame" x="0.0" y="222" width="375" height="84"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
@@ -2254,6 +2254,111 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="v2O-6g-Gcg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1775" y="1714"/>
+        </scene>
+        <!--Referral Code-->
+        <scene sceneID="3ba-J6-IM2">
+            <objects>
+                <viewController storyboardIdentifier="APCReferralCodeViewController" title="Referral Code" id="fgW-Yp-m9v" customClass="APCReferralCodeViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="TBW-8k-RP4"/>
+                        <viewControllerLayoutGuide type="bottom" id="kEE-VA-SEc"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="lIi-RE-MlI">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Optional" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bKn-QS-chR" customClass="APCFormTextField">
+                                <rect key="frame" x="132" y="227" width="227" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="PMy-8S-Aqf"/>
+                                </constraints>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet"/>
+                                <connections>
+                                    <outlet property="delegate" destination="fgW-Yp-m9v" id="ggt-9O-4Yf"/>
+                                </connections>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do you have a referral code? Please enter it below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilE-T0-2gr">
+                                <rect key="frame" x="59" y="93" width="257" height="89"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="89" id="M4W-9x-O2J"/>
+                                    <constraint firstAttribute="width" constant="257" id="cfM-dX-aCe"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zRy-SZ-ms9">
+                                <rect key="frame" x="0.0" y="210" width="375" height="1"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="C5Y-OT-5Gj"/>
+                                </constraints>
+                            </view>
+                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PWn-IA-aOV">
+                                <rect key="frame" x="0.0" y="270" width="375" height="1"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="1kO-Np-Rtf"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Referral code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XlO-Aa-ufk">
+                                <rect key="frame" x="16" y="231" width="101" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="E1L-Or-pLM"/>
+                                    <constraint firstAttribute="width" constant="101" id="fOn-jS-0S4"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Example: ref_code" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yls-YJ-xOG">
+                                <rect key="frame" x="113" y="279" width="149" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="149" id="8lx-u3-Ljx"/>
+                                    <constraint firstAttribute="height" constant="21" id="VCA-RG-Toj"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="ilE-T0-2gr" firstAttribute="centerX" secondItem="lIi-RE-MlI" secondAttribute="centerX" id="38w-IP-uF3"/>
+                            <constraint firstItem="zRy-SZ-ms9" firstAttribute="top" secondItem="ilE-T0-2gr" secondAttribute="bottom" constant="28" id="CvF-sD-QNi"/>
+                            <constraint firstItem="yls-YJ-xOG" firstAttribute="top" secondItem="PWn-IA-aOV" secondAttribute="bottom" constant="8" id="Elu-Cm-EBg"/>
+                            <constraint firstItem="XlO-Aa-ufk" firstAttribute="leading" secondItem="lIi-RE-MlI" secondAttribute="leadingMargin" id="JpY-Lz-1AY"/>
+                            <constraint firstAttribute="trailing" secondItem="zRy-SZ-ms9" secondAttribute="trailing" id="QP9-Ay-iKK"/>
+                            <constraint firstItem="PWn-IA-aOV" firstAttribute="top" secondItem="bKn-QS-chR" secondAttribute="bottom" constant="13" id="RYb-mQ-VEr"/>
+                            <constraint firstItem="bKn-QS-chR" firstAttribute="trailing" secondItem="lIi-RE-MlI" secondAttribute="trailingMargin" id="e5b-gi-f71"/>
+                            <constraint firstAttribute="trailing" secondItem="PWn-IA-aOV" secondAttribute="trailing" id="fmx-D9-Vem"/>
+                            <constraint firstItem="ilE-T0-2gr" firstAttribute="top" secondItem="TBW-8k-RP4" secondAttribute="bottom" constant="29" id="gVV-0P-rTw"/>
+                            <constraint firstItem="yls-YJ-xOG" firstAttribute="centerX" secondItem="lIi-RE-MlI" secondAttribute="centerX" id="jc3-2b-QZk"/>
+                            <constraint firstItem="XlO-Aa-ufk" firstAttribute="top" secondItem="zRy-SZ-ms9" secondAttribute="bottom" constant="20" id="lMZ-A6-VeB"/>
+                            <constraint firstItem="PWn-IA-aOV" firstAttribute="leading" secondItem="lIi-RE-MlI" secondAttribute="leading" id="nSf-sZ-Og5"/>
+                            <constraint firstItem="bKn-QS-chR" firstAttribute="leading" secondItem="XlO-Aa-ufk" secondAttribute="trailing" constant="15" id="slQ-2C-HXw"/>
+                            <constraint firstItem="bKn-QS-chR" firstAttribute="top" secondItem="zRy-SZ-ms9" secondAttribute="bottom" constant="16" id="syr-fQ-f8F"/>
+                            <constraint firstItem="zRy-SZ-ms9" firstAttribute="leading" secondItem="lIi-RE-MlI" secondAttribute="leading" id="tg6-SO-pQT"/>
+                        </constraints>
+                    </view>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="Referral Code" id="oPN-FX-Qcu">
+                        <barButtonItem key="rightBarButtonItem" title="Next" id="kKk-Ov-QpI">
+                            <connections>
+                                <action selector="nextHit:" destination="fgW-Yp-m9v" id="yGI-4v-WgJ"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="textField" destination="bKn-QS-chR" id="I6J-lL-zxo"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yrJ-1a-oqG" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1366" y="1037"/>
         </scene>
     </scenes>
     <resources>

--- a/APCAppCore/APCAppCore/UI/Onboarding/Base.lproj/APCOnboarding.storyboard
+++ b/APCAppCore/APCAppCore/UI/Onboarding/Base.lproj/APCOnboarding.storyboard
@@ -76,7 +76,7 @@
                                         <rect key="frame" x="0.0" y="22" width="320" height="76"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fbI-gd-rWo" id="yzD-4h-Ikj">
-                                            <rect key="frame" x="0.0" y="0.0" width="287" height="75"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="287" height="75.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EvN-HI-qCw">
@@ -498,7 +498,7 @@
                                         <rect key="frame" x="0.0" y="22" width="320" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1EE-D5-O3r" id="PZt-Ax-aBB">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="54"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="54.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="twitter_icon" translatesAutoresizingMaskIntoConstraints="NO" id="a81-fC-z9f">
@@ -863,7 +863,7 @@
                                 <rect key="frame" x="0.0" y="278" width="375" height="65"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2wP-yF-lkA" id="OqD-n2-TBh">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="JQh-zw-o59">
@@ -904,7 +904,7 @@
                                 <rect key="frame" x="0.0" y="343" width="375" height="65"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DnC-25-upo" id="vaB-Ie-snu">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="guc-NA-MN5">
@@ -944,7 +944,7 @@
                                 <rect key="frame" x="0.0" y="408" width="375" height="65"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="I8V-sw-jd9" id="BUy-yw-Oxz">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="za5-xM-hxy">
@@ -986,7 +986,7 @@
                                 <rect key="frame" x="0.0" y="473" width="375" height="164"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3nR-eU-2lq" id="g2T-yr-9KU">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="163"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="163.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <datePicker contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="SZm-Uz-5Zp">
@@ -1093,7 +1093,7 @@
                                         <rect key="frame" x="0.0" y="32" width="375" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ou2-PJ-dKI" id="ZCB-gg-XxM">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="63"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="63.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="EqO-DT-mOm">
@@ -1131,7 +1131,7 @@
                                         <rect key="frame" x="0.0" y="96" width="375" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2jx-mM-6KH" id="WvK-Z4-TRu">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="63"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="63.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="boZ-cz-pDf">
@@ -1259,7 +1259,7 @@
                                         <rect key="frame" x="0.0" y="59" width="375" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Mf9-aU-KDH" id="bLU-pj-BTQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZNj-BL-O64">
@@ -1342,7 +1342,7 @@
                                 <rect key="frame" x="0.0" y="22" width="375" height="65"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lJ6-Qj-KGv" id="urg-0I-biT">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aoS-Ay-W9H">
@@ -1389,7 +1389,7 @@
                                 <rect key="frame" x="0.0" y="87" width="375" height="164"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sog-Is-AtN" id="zB0-uv-q8o">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="163"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="163.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <datePicker contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="asa-dd-aCq">
@@ -1425,7 +1425,7 @@
                                 <rect key="frame" x="0.0" y="251" width="375" height="65"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1Pi-q5-6kh" id="ifk-93-yoc">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="64.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HQF-Pi-Ndp">
@@ -1771,7 +1771,7 @@
                                         </collectionViewFlowLayout>
                                         <cells>
                                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="APCStudyVideoCollectionViewCell" id="6DX-f5-uTt" customClass="APCStudyVideoCollectionViewCell">
-                                                <rect key="frame" x="0.0" y="-1" width="320" height="343"/>
+                                                <rect key="frame" x="0.0" y="-0.5" width="320" height="343"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                                     <rect key="frame" x="0.0" y="0.0" width="320" height="343"/>
@@ -1882,7 +1882,7 @@
                                                 </connections>
                                             </collectionViewCell>
                                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="APCStudyLandingCollectionViewCell" id="4tb-fc-aMX" customClass="APCStudyLandingCollectionViewCell">
-                                                <rect key="frame" x="320" y="-1" width="320" height="343"/>
+                                                <rect key="frame" x="320" y="-0.5" width="320" height="343"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                                     <rect key="frame" x="0.0" y="0.0" width="320" height="343"/>
@@ -2011,7 +2011,7 @@
                                                 </connections>
                                             </collectionViewCell>
                                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="APCStudyOverviewCollectionViewCell" id="6LZ-IM-aqc" customClass="APCStudyOverviewCollectionViewCell">
-                                                <rect key="frame" x="640" y="-1" width="320" height="343"/>
+                                                <rect key="frame" x="640" y="-0.5" width="320" height="343"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                                     <rect key="frame" x="0.0" y="0.0" width="320" height="343"/>
@@ -2256,109 +2256,104 @@
             <point key="canvasLocation" x="1775" y="1714"/>
         </scene>
         <!--Referral Code-->
-        <scene sceneID="3ba-J6-IM2">
+        <scene sceneID="FEz-0c-yDE">
             <objects>
-                <viewController storyboardIdentifier="APCReferralCodeViewController" title="Referral Code" id="fgW-Yp-m9v" customClass="APCReferralCodeViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="APCReferralCodeViewController" title="Referral Code" id="URz-Qz-ZBC" customClass="APCReferralCodeViewController" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="TBW-8k-RP4"/>
-                        <viewControllerLayoutGuide type="bottom" id="kEE-VA-SEc"/>
+                        <viewControllerLayoutGuide type="top" id="piG-ek-TEA"/>
+                        <viewControllerLayoutGuide type="bottom" id="zdl-tT-8Ml"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="lIi-RE-MlI">
+                    <view key="view" contentMode="scaleToFill" id="gL4-Vj-cw0">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Optional" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bKn-QS-chR" customClass="APCFormTextField">
-                                <rect key="frame" x="132" y="227" width="227" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="PMy-8S-Aqf"/>
-                                </constraints>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet"/>
-                                <connections>
-                                    <outlet property="delegate" destination="fgW-Yp-m9v" id="ggt-9O-4Yf"/>
-                                </connections>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do you have a referral code? Please enter it below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilE-T0-2gr">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do you have a referral code? Please enter it below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nrZ-Ob-E0j">
                                 <rect key="frame" x="59" y="93" width="257" height="89"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="89" id="M4W-9x-O2J"/>
-                                    <constraint firstAttribute="width" constant="257" id="cfM-dX-aCe"/>
+                                    <constraint firstAttribute="height" constant="89" id="Ku9-fU-62A"/>
+                                    <constraint firstAttribute="width" constant="257" id="MGF-1i-za3"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zRy-SZ-ms9">
+                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bDT-qy-LHz">
                                 <rect key="frame" x="0.0" y="210" width="375" height="1"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="C5Y-OT-5Gj"/>
+                                    <constraint firstAttribute="height" constant="1" id="dp1-aI-srq"/>
                                 </constraints>
                             </view>
-                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PWn-IA-aOV">
-                                <rect key="frame" x="0.0" y="270" width="375" height="1"/>
+                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iIK-0c-r6m">
+                                <rect key="frame" x="0.0" y="268" width="375" height="1"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="1kO-Np-Rtf"/>
+                                    <constraint firstAttribute="height" constant="1" id="a8V-DF-jlh"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Referral code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XlO-Aa-ufk">
-                                <rect key="frame" x="16" y="231" width="101" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Referral code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MOu-SL-D27">
+                                <rect key="frame" x="16" y="230" width="101" height="21"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="21" id="E1L-Or-pLM"/>
-                                    <constraint firstAttribute="width" constant="101" id="fOn-jS-0S4"/>
+                                    <constraint firstAttribute="height" constant="21" id="KAl-Vw-9eI"/>
+                                    <constraint firstAttribute="width" constant="101" id="emM-h1-aMf"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Example: ref_code" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yls-YJ-xOG">
-                                <rect key="frame" x="113" y="279" width="149" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Example: 12-345-678" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKb-Y4-Cdw">
+                                <rect key="frame" x="113" y="277" width="149" height="21"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="149" id="8lx-u3-Ljx"/>
-                                    <constraint firstAttribute="height" constant="21" id="VCA-RG-Toj"/>
+                                    <constraint firstAttribute="width" constant="149" id="HhC-AN-biV"/>
+                                    <constraint firstAttribute="height" constant="21" id="VZC-Vc-QyL"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OUO-H3-6HB">
+                                <rect key="frame" x="125" y="213" width="250" height="56"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="56" id="i8i-g6-rK4"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="ilE-T0-2gr" firstAttribute="centerX" secondItem="lIi-RE-MlI" secondAttribute="centerX" id="38w-IP-uF3"/>
-                            <constraint firstItem="zRy-SZ-ms9" firstAttribute="top" secondItem="ilE-T0-2gr" secondAttribute="bottom" constant="28" id="CvF-sD-QNi"/>
-                            <constraint firstItem="yls-YJ-xOG" firstAttribute="top" secondItem="PWn-IA-aOV" secondAttribute="bottom" constant="8" id="Elu-Cm-EBg"/>
-                            <constraint firstItem="XlO-Aa-ufk" firstAttribute="leading" secondItem="lIi-RE-MlI" secondAttribute="leadingMargin" id="JpY-Lz-1AY"/>
-                            <constraint firstAttribute="trailing" secondItem="zRy-SZ-ms9" secondAttribute="trailing" id="QP9-Ay-iKK"/>
-                            <constraint firstItem="PWn-IA-aOV" firstAttribute="top" secondItem="bKn-QS-chR" secondAttribute="bottom" constant="13" id="RYb-mQ-VEr"/>
-                            <constraint firstItem="bKn-QS-chR" firstAttribute="trailing" secondItem="lIi-RE-MlI" secondAttribute="trailingMargin" id="e5b-gi-f71"/>
-                            <constraint firstAttribute="trailing" secondItem="PWn-IA-aOV" secondAttribute="trailing" id="fmx-D9-Vem"/>
-                            <constraint firstItem="ilE-T0-2gr" firstAttribute="top" secondItem="TBW-8k-RP4" secondAttribute="bottom" constant="29" id="gVV-0P-rTw"/>
-                            <constraint firstItem="yls-YJ-xOG" firstAttribute="centerX" secondItem="lIi-RE-MlI" secondAttribute="centerX" id="jc3-2b-QZk"/>
-                            <constraint firstItem="XlO-Aa-ufk" firstAttribute="top" secondItem="zRy-SZ-ms9" secondAttribute="bottom" constant="20" id="lMZ-A6-VeB"/>
-                            <constraint firstItem="PWn-IA-aOV" firstAttribute="leading" secondItem="lIi-RE-MlI" secondAttribute="leading" id="nSf-sZ-Og5"/>
-                            <constraint firstItem="bKn-QS-chR" firstAttribute="leading" secondItem="XlO-Aa-ufk" secondAttribute="trailing" constant="15" id="slQ-2C-HXw"/>
-                            <constraint firstItem="bKn-QS-chR" firstAttribute="top" secondItem="zRy-SZ-ms9" secondAttribute="bottom" constant="16" id="syr-fQ-f8F"/>
-                            <constraint firstItem="zRy-SZ-ms9" firstAttribute="leading" secondItem="lIi-RE-MlI" secondAttribute="leading" id="tg6-SO-pQT"/>
+                            <constraint firstItem="gKb-Y4-Cdw" firstAttribute="top" secondItem="iIK-0c-r6m" secondAttribute="bottom" constant="8" id="0ba-l6-JCF"/>
+                            <constraint firstItem="OUO-H3-6HB" firstAttribute="leading" secondItem="MOu-SL-D27" secondAttribute="trailing" constant="8" id="0qw-se-neY"/>
+                            <constraint firstItem="nrZ-Ob-E0j" firstAttribute="top" secondItem="piG-ek-TEA" secondAttribute="bottom" constant="29" id="4Zx-Nf-yA5"/>
+                            <constraint firstItem="OUO-H3-6HB" firstAttribute="top" secondItem="nrZ-Ob-E0j" secondAttribute="bottom" constant="31" id="9ny-gw-MeG"/>
+                            <constraint firstItem="bDT-qy-LHz" firstAttribute="top" secondItem="nrZ-Ob-E0j" secondAttribute="bottom" constant="28" id="BzA-4O-hHL"/>
+                            <constraint firstItem="bDT-qy-LHz" firstAttribute="leading" secondItem="gL4-Vj-cw0" secondAttribute="leading" id="CNV-ds-RrB"/>
+                            <constraint firstItem="MOu-SL-D27" firstAttribute="top" secondItem="bDT-qy-LHz" secondAttribute="bottom" constant="19" id="NL8-Rb-eu5"/>
+                            <constraint firstItem="nrZ-Ob-E0j" firstAttribute="centerX" secondItem="gL4-Vj-cw0" secondAttribute="centerX" id="Ujp-CU-YzR"/>
+                            <constraint firstItem="gKb-Y4-Cdw" firstAttribute="centerX" secondItem="gL4-Vj-cw0" secondAttribute="centerX" id="Zdx-tK-hmV"/>
+                            <constraint firstAttribute="trailing" secondItem="iIK-0c-r6m" secondAttribute="trailing" id="ad8-Xr-GCp"/>
+                            <constraint firstItem="iIK-0c-r6m" firstAttribute="leading" secondItem="gL4-Vj-cw0" secondAttribute="leading" id="cAv-Pl-oBO"/>
+                            <constraint firstItem="gKb-Y4-Cdw" firstAttribute="top" secondItem="OUO-H3-6HB" secondAttribute="bottom" constant="8" id="cAw-0I-6iS"/>
+                            <constraint firstItem="MOu-SL-D27" firstAttribute="leading" secondItem="gL4-Vj-cw0" secondAttribute="leadingMargin" id="cfb-0s-gDQ"/>
+                            <constraint firstAttribute="trailing" secondItem="OUO-H3-6HB" secondAttribute="trailing" id="flc-oW-yPo"/>
+                            <constraint firstAttribute="trailing" secondItem="bDT-qy-LHz" secondAttribute="trailing" id="ye3-Yv-5AB"/>
                         </constraints>
                     </view>
                     <toolbarItems/>
-                    <navigationItem key="navigationItem" title="Referral Code" id="oPN-FX-Qcu">
-                        <barButtonItem key="rightBarButtonItem" title="Next" id="kKk-Ov-QpI">
+                    <navigationItem key="navigationItem" title="Referral Code" id="Fja-A8-YUU">
+                        <barButtonItem key="rightBarButtonItem" title="Next" id="uby-L0-l0T">
                             <connections>
-                                <action selector="nextHit:" destination="fgW-Yp-m9v" id="yGI-4v-WgJ"/>
+                                <action selector="nextHit:" destination="URz-Qz-ZBC" id="NVK-SC-Tk0"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
-                        <outlet property="textField" destination="bKn-QS-chR" id="I6J-lL-zxo"/>
+                        <outlet property="textFieldContainView" destination="OUO-H3-6HB" id="SLM-m1-DmG"/>
                     </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="yrJ-1a-oqG" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ERX-6z-lh7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1366" y="1037"/>
+            <point key="canvasLocation" x="1350" y="1046"/>
         </scene>
     </scenes>
     <resources>

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCAddReferralCodeViewController.h
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCAddReferralCodeViewController.h
@@ -1,0 +1,13 @@
+//
+//  APCAddReferralCodeViewController.h
+//  APCAppCore
+//
+//  Created by Josh Bruhin on 2/6/17.
+//  Copyright © 2017 Apple, Inc. All rights reserved.
+//
+
+#import "APCReferralCodeViewController.h"
+
+@interface APCAddReferralCodeViewController : APCReferralCodeViewController
+
+@end

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCAddReferralCodeViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCAddReferralCodeViewController.m
@@ -1,0 +1,160 @@
+//
+//  APCAddReferralCodeViewController.m
+//  APCAppCore
+//
+//  Created by Josh Bruhin on 2/6/17.
+//  Copyright © 2017 Apple, Inc. All rights reserved.
+//
+
+#import "APCAddReferralCodeViewController.h"
+#import "APCLocalization.h"
+#import "APCSpinnerViewController.h"
+#import "APCLog.h"
+#import "APCCustomBackButton.h"
+#import "APCAppDelegate.h"
+
+#import "NSError+Bridge.h"
+#import "UIColor+APCAppearance.h"
+
+#import <BridgeSDK/BridgeSDK.h>
+
+@interface APCReferralCodeViewController ()
+- (void)setupAppearance;
+@end
+
+@interface APCAddReferralCodeViewController ()
+
+@end
+
+@implementation APCAddReferralCodeViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self setupAppearance];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.textField becomeFirstResponder];
+}
+
+- (void)setupAppearance {
+    
+    [super setupAppearance];
+    
+    UIBarButtonItem  *backster = [APCCustomBackButton customBackBarButtonItemWithTarget:self action:@selector(goBack) tintColor:[UIColor appPrimaryColor]];
+    [self.navigationItem setLeftBarButtonItem:backster];
+}
+
+#pragma mark - Overrides
+
+- (void)setupSaveButton {
+    UIBarButtonItem *saveBarButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"Save", @"APCAppCore", APCBundle(), @"Save", @"")
+                                                                      style:UIBarButtonItemStylePlain
+                                                                     target:self
+                                                                     action:@selector(saveHit:)];
+    self.saveButton = saveBarButton;
+    self.saveButton.enabled = NO;
+}
+
+- (void)setSaveButton:(UIBarButtonItem *)saveButton {
+    self.navigationItem.rightBarButtonItem = saveButton;
+}
+- (UIBarButtonItem*)saveButton {
+    return self.navigationItem.rightBarButtonItem;
+}
+
+- (APCUser *)currentUser {
+    return [[APCAppDelegate sharedAppDelegate] dataSubstrate].currentUser;
+}
+
+- (void)textFieldTextDidChangeTo:(NSString*)text {
+    
+    [super textFieldTextDidChangeTo:text];
+    
+    // if we have no text, then disable our save button
+    if (text.length == 0) {
+        self.saveButton.enabled = NO;
+    }
+}
+
+#pragma mark - Actions
+
+- (IBAction)saveHit:(id __unused)sender {
+    
+    self.saveButton.enabled = NO;
+    
+    [self.textField resignFirstResponder];
+    
+    APCSpinnerViewController *spinnerController = [[APCSpinnerViewController alloc] init];
+    [self presentViewController:spinnerController animated:YES completion:nil];
+    
+    typeof(self) __weak weakSelf = self;
+    [SBBComponent(SBBParticipantManager) setExternalIdentifier:self.textField.text completion:^(id  _Nullable responseObject __unused, NSError * _Nullable error) {
+        
+        
+        // get back to main thread
+        dispatch_async(dispatch_get_main_queue(), ^{
+            
+            if (error) {
+                
+                self.saveButton.enabled = YES;
+
+                APCLogError2 (error);
+                
+                if (error.code == SBBErrorCodeInternetNotConnected || error.code == SBBErrorCodeServerNotReachable || error.code == SBBErrorCodeServerUnderMaintenance) {
+                    [spinnerController dismissViewControllerAnimated:NO completion:^{
+                        
+                        UIAlertController *alertView = [UIAlertController alertControllerWithTitle:NSLocalizedStringWithDefaultValue(@"Referral Code", @"APCAppCore", APCBundle(), @"Referral Code", @"")
+                                                                                           message:error.localizedDescription
+                                                                                    preferredStyle:UIAlertControllerStyleAlert];
+                        
+                        UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault
+                                                                              handler:^(UIAlertAction * __unused action) {}];
+                        
+                        [alertView addAction:defaultAction];
+                        [self presentViewController:alertView animated:YES completion:nil];
+                    }];
+                } else {
+                    [spinnerController dismissViewControllerAnimated:NO completion:^{
+                        
+                        UIAlertController *alertView = [UIAlertController alertControllerWithTitle:NSLocalizedStringWithDefaultValue(@"Referral Code", @"APCAppCore", APCBundle(), @"Referral Code", @"")
+                                                                                           message:error.message
+                                                                                    preferredStyle:UIAlertControllerStyleAlert];
+                        
+                        UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"Cancel", @"APCAppCore", APCBundle(), @"Cancel", @"") style:UIAlertActionStyleCancel
+                                                                             handler:^(UIAlertAction * __unused action) {
+                                                                                 [self goBack];
+                                                                             }];
+                        
+                        UIAlertAction* retryAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"Try Again", @"APCAppCore", APCBundle(), @"Try Again", nil) style:UIAlertActionStyleDefault
+                                                                            handler:^(UIAlertAction * __unused action) {
+                                                                                [weakSelf saveHit:nil];
+                                                                            }];
+                        
+                        [alertView addAction:cancelAction];
+                        [alertView addAction:retryAction];
+                        [self presentViewController:alertView animated:YES completion:nil];
+                        
+                    }];
+                }
+            }
+            else
+            {
+                // save our new referral code to current user
+                [self currentUser].externalId = weakSelf.textField.text;
+                
+                [spinnerController showCheckmarkThenDismissCompletion:^{
+                    [weakSelf goBack];
+                }];
+            }
+        });
+    }];
+}
+
+- (void)goBack {
+    [self.textField resignFirstResponder];
+    [self.navigationController popToRootViewControllerAnimated:YES];
+}
+
+@end

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCAddReferralCodeViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCAddReferralCodeViewController.m
@@ -20,6 +20,9 @@
 
 @interface APCReferralCodeViewController ()
 - (void)setupAppearance;
+- (NSString*)finalString;
+- (void)resignFirstResponderOnAll;
+- (BOOL)codeIsValid;
 @end
 
 @interface APCAddReferralCodeViewController ()
@@ -30,21 +33,15 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    [self setupAppearance];
-}
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [self.textField becomeFirstResponder];
-}
-
-- (void)setupAppearance {
-    
-    [super setupAppearance];
-    
     UIBarButtonItem  *backster = [APCCustomBackButton customBackBarButtonItemWithTarget:self action:@selector(goBack) tintColor:[UIColor appPrimaryColor]];
     [self.navigationItem setLeftBarButtonItem:backster];
 }
+//
+//- (void)viewWillAppear:(BOOL)animated {
+//    [super viewWillAppear:animated];
+////    [self.textField becomeFirstResponder];
+//}
 
 #pragma mark - Overrides
 
@@ -68,14 +65,8 @@
     return [[APCAppDelegate sharedAppDelegate] dataSubstrate].currentUser;
 }
 
-- (void)textFieldTextDidChangeTo:(NSString*)text {
-    
-    [super textFieldTextDidChangeTo:text];
-    
-    // if we have no text, then disable our save button
-    if (text.length == 0) {
-        self.saveButton.enabled = NO;
-    }
+- (void)updateControls {
+    self.saveButton.enabled = [self codeIsValid];
 }
 
 #pragma mark - Actions
@@ -84,13 +75,13 @@
     
     self.saveButton.enabled = NO;
     
-    [self.textField resignFirstResponder];
+    [self resignFirstResponderOnAll];
     
     APCSpinnerViewController *spinnerController = [[APCSpinnerViewController alloc] init];
     [self presentViewController:spinnerController animated:YES completion:nil];
     
     typeof(self) __weak weakSelf = self;
-    [SBBComponent(SBBParticipantManager) setExternalIdentifier:self.textField.text completion:^(id  _Nullable responseObject __unused, NSError * _Nullable error) {
+    [SBBComponent(SBBParticipantManager) setExternalIdentifier:[self finalString] completion:^(id  _Nullable responseObject __unused, NSError * _Nullable error) {
         
         
         // get back to main thread
@@ -142,7 +133,7 @@
             else
             {
                 // save our new referral code to current user
-                [self currentUser].externalId = weakSelf.textField.text;
+                [self currentUser].externalId = [weakSelf finalString];
                 
                 [spinnerController showCheckmarkThenDismissCompletion:^{
                     [weakSelf goBack];
@@ -153,7 +144,7 @@
 }
 
 - (void)goBack {
-    [self.textField resignFirstResponder];
+    [self resignFirstResponderOnAll];
     [self.navigationController popToRootViewControllerAnimated:YES];
 }
 

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/APCProfileViewController.m
@@ -43,6 +43,7 @@
 #import "APCWebViewController.h"
 #import "APCSettingsViewController.h"
 #import "APCSpinnerViewController.h"
+#import "APCAddReferralCodeViewController.h"
 #import "APCTableViewItem.h"
 #import "APCAppDelegate.h"
 #import "APCTasksReminderManager.h"
@@ -852,6 +853,21 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
             [rowItems addObject:row];
         }
         
+        {
+            APCTableViewItem *field = [APCTableViewItem new];
+            field.caption = NSLocalizedStringWithDefaultValue(@"Enter Referral Code", @"APCAppCore", APCBundle(), @"Enter Referral Code", @"");
+            field.reuseIdentifier = kAPCDefaultTableViewCellIdentifier;
+            field.textAlignnment = NSTextAlignmentRight;
+            field.editable = NO;
+            field.showChevron = YES;
+            field.selectionStyle = UITableViewCellSelectionStyleGray;
+            
+            APCTableViewRow *row = [APCTableViewRow new];
+            row.item = field;
+            row.itemType = kAPCSettingsItemTypeReferralCode;
+            [rowItems addObject:row];
+        }
+
         APCTableViewSection *section = [APCTableViewSection new];
         section.rows = [NSArray arrayWithArray:rowItems];
         section.sectionTitle = @"";
@@ -1081,6 +1097,16 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
             }
                 break;
             
+            case kAPCSettingsItemTypeReferralCode:
+            {
+                if (!self.isEditing){
+                    [self showReferralCode];
+                }
+                [tableView deselectRowAtIndexPath:indexPath animated:YES];
+                
+            }
+                break;
+
             case kAPCSettingsItemTypeReminderOnOff:
             {
                 if (!self.isEditing){
@@ -1420,6 +1446,9 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
                 case kAPCUserInfoItemTypeReviewConsent:
                     break;
                 
+                case kAPCSettingsItemTypeReferralCode:
+                    break;
+                    
                 case kAPCSettingsItemTypePrivacyPolicy:
                     break;
                 
@@ -1751,6 +1780,14 @@ static NSString * const kAPCRightDetailTableViewCellIdentifier = @"APCRightDetai
     }];
 }
 
+#pragma mark - Referral Code
+
+- (void)showReferralCode
+{
+    APCAddReferralCodeViewController *viewController = [[UIStoryboard storyboardWithName:@"APCProfile" bundle:[NSBundle appleCoreBundle]] instantiateViewControllerWithIdentifier:@"APCAddReferralCodeViewController"];
+    
+    [self.navigationController pushViewController:viewController animated:YES];
+}
 
 
 #pragma mark - Review Consent helper methods

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/Base.lproj/APCProfile.storyboard
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/Base.lproj/APCProfile.storyboard
@@ -1137,109 +1137,104 @@
             <point key="canvasLocation" x="1794" y="1835"/>
         </scene>
         <!--Referral Code-->
-        <scene sceneID="vBa-WY-ce3">
+        <scene sceneID="0vd-1c-BZ3">
             <objects>
-                <viewController storyboardIdentifier="APCAddReferralCodeViewController" title="Referral Code" id="Acj-Zo-NdC" customClass="APCAddReferralCodeViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="APCAddReferralCodeViewController" title="Referral Code" id="JUu-NY-P5e" customClass="APCAddReferralCodeViewController" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="uB8-mG-0j9"/>
-                        <viewControllerLayoutGuide type="bottom" id="5Ae-Qd-u15"/>
+                        <viewControllerLayoutGuide type="top" id="tLr-hG-iBW"/>
+                        <viewControllerLayoutGuide type="bottom" id="Aob-Ri-CLh"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="M0p-UP-s11">
+                    <view key="view" contentMode="scaleToFill" id="nTu-Ab-2ZC">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Optional" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bcb-Pt-ihJ" customClass="APCFormTextField">
-                                <rect key="frame" x="132" y="227" width="172" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="sag-e9-U07"/>
-                                </constraints>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet"/>
-                                <connections>
-                                    <outlet property="delegate" destination="Acj-Zo-NdC" id="e17-5i-XeD"/>
-                                </connections>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do you have a referral code? Please enter it below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9WY-fT-D40">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do you have a referral code? Please enter it below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hBZ-fv-mGH">
                                 <rect key="frame" x="32" y="93" width="257" height="89"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="89" id="GUk-u1-N8O"/>
-                                    <constraint firstAttribute="width" constant="257" id="y4y-RU-5Fy"/>
+                                    <constraint firstAttribute="height" constant="89" id="PDf-E0-dcH"/>
+                                    <constraint firstAttribute="width" constant="257" id="gck-Km-fvv"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9XQ-gO-TbU">
+                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L91-x5-W2J">
                                 <rect key="frame" x="0.0" y="210" width="320" height="1"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="p3t-Oh-i82"/>
+                                    <constraint firstAttribute="height" constant="1" id="zDK-6e-W0b"/>
                                 </constraints>
                             </view>
-                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QFD-Ns-QhZ">
-                                <rect key="frame" x="0.0" y="270" width="320" height="1"/>
+                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SOs-hF-AmO">
+                                <rect key="frame" x="0.0" y="268" width="320" height="1"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="Ggl-b9-z2I"/>
+                                    <constraint firstAttribute="height" constant="1" id="WcW-YX-zkh"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Referral code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kx4-Ul-Wa4">
-                                <rect key="frame" x="16" y="231" width="101" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Referral code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o6l-qS-4Tz">
+                                <rect key="frame" x="16" y="230" width="101" height="21"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="101" id="Xlt-iH-0pG"/>
-                                    <constraint firstAttribute="height" constant="21" id="qtz-v7-M1g"/>
+                                    <constraint firstAttribute="height" constant="21" id="FAO-Qt-Wia"/>
+                                    <constraint firstAttribute="width" constant="101" id="YiV-bl-02r"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Example: ref_code" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wlt-a9-GwR">
-                                <rect key="frame" x="86" y="279" width="149" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Example: 12-345-678" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLO-Cx-ZGI">
+                                <rect key="frame" x="86" y="277" width="149" height="21"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="21" id="JBV-yh-RPz"/>
-                                    <constraint firstAttribute="width" constant="149" id="hdr-lt-wQn"/>
+                                    <constraint firstAttribute="width" constant="149" id="34Q-fc-e3q"/>
+                                    <constraint firstAttribute="height" constant="21" id="ydT-FP-ydB"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2u1-1d-OTQ">
+                                <rect key="frame" x="125" y="213" width="195" height="56"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="56" id="Yn4-n2-Tz4"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="9XQ-gO-TbU" firstAttribute="top" secondItem="9WY-fT-D40" secondAttribute="bottom" constant="28" id="1X5-vn-UT1"/>
-                            <constraint firstItem="Kx4-Ul-Wa4" firstAttribute="leading" secondItem="M0p-UP-s11" secondAttribute="leadingMargin" id="FbA-cD-y7I"/>
-                            <constraint firstItem="Bcb-Pt-ihJ" firstAttribute="leading" secondItem="Kx4-Ul-Wa4" secondAttribute="trailing" constant="15" id="Fmo-oN-Utx"/>
-                            <constraint firstItem="Wlt-a9-GwR" firstAttribute="top" secondItem="QFD-Ns-QhZ" secondAttribute="bottom" constant="8" id="Kzj-tu-NAw"/>
-                            <constraint firstItem="Kx4-Ul-Wa4" firstAttribute="top" secondItem="9XQ-gO-TbU" secondAttribute="bottom" constant="20" id="WGs-ZJ-iQR"/>
-                            <constraint firstItem="QFD-Ns-QhZ" firstAttribute="leading" secondItem="M0p-UP-s11" secondAttribute="leading" id="XAv-O1-74e"/>
-                            <constraint firstItem="Wlt-a9-GwR" firstAttribute="centerX" secondItem="M0p-UP-s11" secondAttribute="centerX" id="ZDT-Ax-iG8"/>
-                            <constraint firstItem="QFD-Ns-QhZ" firstAttribute="top" secondItem="Bcb-Pt-ihJ" secondAttribute="bottom" constant="13" id="Zd1-CD-JFQ"/>
-                            <constraint firstAttribute="trailing" secondItem="QFD-Ns-QhZ" secondAttribute="trailing" id="ZeS-VK-BKm"/>
-                            <constraint firstItem="Bcb-Pt-ihJ" firstAttribute="top" secondItem="9XQ-gO-TbU" secondAttribute="bottom" constant="16" id="eL8-WH-DHH"/>
-                            <constraint firstItem="9WY-fT-D40" firstAttribute="top" secondItem="uB8-mG-0j9" secondAttribute="bottom" constant="29" id="lX1-ri-aDZ"/>
-                            <constraint firstItem="9XQ-gO-TbU" firstAttribute="leading" secondItem="M0p-UP-s11" secondAttribute="leading" id="ldo-22-ZUC"/>
-                            <constraint firstAttribute="trailing" secondItem="9XQ-gO-TbU" secondAttribute="trailing" id="sNk-Ju-XwW"/>
-                            <constraint firstItem="Bcb-Pt-ihJ" firstAttribute="trailing" secondItem="M0p-UP-s11" secondAttribute="trailingMargin" id="vGv-5x-tyN"/>
-                            <constraint firstItem="9WY-fT-D40" firstAttribute="centerX" secondItem="M0p-UP-s11" secondAttribute="centerX" id="vKI-Tu-qR1"/>
+                            <constraint firstItem="SOs-hF-AmO" firstAttribute="leading" secondItem="nTu-Ab-2ZC" secondAttribute="leading" id="37K-U6-Dbl"/>
+                            <constraint firstItem="o6l-qS-4Tz" firstAttribute="leading" secondItem="nTu-Ab-2ZC" secondAttribute="leadingMargin" id="4Dx-EJ-quc"/>
+                            <constraint firstAttribute="trailing" secondItem="2u1-1d-OTQ" secondAttribute="trailing" id="BBs-jT-bx0"/>
+                            <constraint firstItem="o6l-qS-4Tz" firstAttribute="top" secondItem="L91-x5-W2J" secondAttribute="bottom" constant="19" id="FNa-S5-bfq"/>
+                            <constraint firstItem="L91-x5-W2J" firstAttribute="leading" secondItem="nTu-Ab-2ZC" secondAttribute="leading" id="KCC-s8-0hB"/>
+                            <constraint firstItem="2u1-1d-OTQ" firstAttribute="top" secondItem="hBZ-fv-mGH" secondAttribute="bottom" constant="31" id="OUU-zc-Gd9"/>
+                            <constraint firstItem="QLO-Cx-ZGI" firstAttribute="centerX" secondItem="nTu-Ab-2ZC" secondAttribute="centerX" id="QOS-Yt-Vf9"/>
+                            <constraint firstItem="L91-x5-W2J" firstAttribute="top" secondItem="hBZ-fv-mGH" secondAttribute="bottom" constant="28" id="QT6-kk-Rj1"/>
+                            <constraint firstItem="hBZ-fv-mGH" firstAttribute="centerX" secondItem="nTu-Ab-2ZC" secondAttribute="centerX" id="XMA-s2-oYl"/>
+                            <constraint firstItem="QLO-Cx-ZGI" firstAttribute="top" secondItem="2u1-1d-OTQ" secondAttribute="bottom" constant="8" id="aIa-r6-lrW"/>
+                            <constraint firstAttribute="trailing" secondItem="L91-x5-W2J" secondAttribute="trailing" id="aUe-gc-JoV"/>
+                            <constraint firstItem="2u1-1d-OTQ" firstAttribute="leading" secondItem="o6l-qS-4Tz" secondAttribute="trailing" constant="8" id="hUA-iA-ClF"/>
+                            <constraint firstItem="hBZ-fv-mGH" firstAttribute="top" secondItem="tLr-hG-iBW" secondAttribute="bottom" constant="29" id="n75-v2-e4m"/>
+                            <constraint firstAttribute="trailing" secondItem="SOs-hF-AmO" secondAttribute="trailing" id="w7e-3F-G3l"/>
+                            <constraint firstItem="QLO-Cx-ZGI" firstAttribute="top" secondItem="SOs-hF-AmO" secondAttribute="bottom" constant="8" id="ycB-yt-1FD"/>
                         </constraints>
                     </view>
                     <toolbarItems/>
-                    <navigationItem key="navigationItem" title="Referral Code" id="YrF-Hl-8IH">
-                        <barButtonItem key="rightBarButtonItem" title="Next" id="FgN-cv-Oyk">
+                    <navigationItem key="navigationItem" title="Referral Code" id="ts3-oR-Qa4">
+                        <barButtonItem key="rightBarButtonItem" title="Next" id="pex-qD-fUn">
                             <connections>
-                                <action selector="nextHit:" destination="Acj-Zo-NdC" id="swz-cI-V2d"/>
+                                <action selector="nextHit:" destination="JUu-NY-P5e" id="K4L-CZ-SFI"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
-                        <outlet property="textField" destination="Bcb-Pt-ihJ" id="SCz-GJ-ubM"/>
+                        <outlet property="textFieldContainView" destination="2u1-1d-OTQ" id="nEc-IX-emX"/>
                     </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Etl-NE-u4L" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="aKq-Ix-n9y" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1382" y="1167"/>
+            <point key="canvasLocation" x="1268" y="1238"/>
         </scene>
     </scenes>
     <resources>

--- a/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/Base.lproj/APCProfile.storyboard
+++ b/APCAppCore/APCAppCore/UI/TabBarControllers/Profile/Base.lproj/APCProfile.storyboard
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="u6G-bF-12V">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11760" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="u6G-bF-12V">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11755"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Profile-->
@@ -13,11 +17,11 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" sectionHeaderHeight="22" sectionFooterHeight="22" id="pPM-kO-BHx">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
-                        <color key="separatorColor" red="0.85098039219999999" green="0.85098039219999999" blue="0.85098039219999999" alpha="1" colorSpace="calibratedRGB"/>
-                        <color key="sectionIndexBackgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="separatorColor" red="0.85098039219999999" green="0.85098039219999999" blue="0.85098039219999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="sectionIndexBackgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <view key="tableHeaderView" contentMode="scaleToFill" id="kqd-X8-uFF">
-                            <rect key="frame" x="0.0" y="64" width="320" height="159"/>
+                            <rect key="frame" x="0.0" y="0.0" width="320" height="159"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wbP-3z-2pl">
@@ -27,7 +31,7 @@
                                         <constraint firstAttribute="width" constant="77" id="gXf-Gr-RbN"/>
                                     </constraints>
                                     <state key="normal" backgroundImage="profilePlaceholder">
-                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </state>
                                     <connections>
                                         <action selector="changeProfileImage:" destination="3ca-8Q-UW8" eventType="touchUpInside" id="vfE-2c-5Hd"/>
@@ -47,13 +51,14 @@
                                         <constraint firstAttribute="height" constant="23" id="UJu-U9-6Gd"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Edit" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gvf-JT-xq5">
                                     <rect key="frame" x="14" y="98" width="49" height="21"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UMm-O6-rLy">
@@ -63,8 +68,8 @@
                                         <constraint firstAttribute="width" constant="91" id="RSb-ed-7cA"/>
                                     </constraints>
                                     <state key="normal" title="Leave Study">
-                                        <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </state>
                                     <connections>
                                         <action selector="leaveStudy:" destination="3ca-8Q-UW8" eventType="touchUpInside" id="F1J-YC-Fme"/>
@@ -78,8 +83,8 @@
                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="91" id="jD9-7P-1Vc"/>
                                     </constraints>
                                     <state key="normal" title="Pause Study">
-                                        <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </state>
                                     <connections>
                                         <action selector="pauseStudy:" destination="3ca-8Q-UW8" eventType="touchUpInside" id="fmX-Sr-zLd"/>
@@ -87,7 +92,7 @@
                                 </button>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BHJ-hN-unW">
                                     <rect key="frame" x="0.0" y="158" width="320" height="1"/>
-                                    <color key="backgroundColor" white="0.90641571969696966" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="backgroundColor" red="0.90641570091247559" green="0.90641570091247559" blue="0.90641570091247559" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="1lX-59-jUb"/>
                                     </constraints>
@@ -98,7 +103,7 @@
                                         <constraint firstAttribute="width" priority="500" constant="195" id="zxr-rh-ff3"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Currently Participating In " lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="bb2-UZ-Wan">
@@ -107,11 +112,11 @@
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="ayW-cn-uG5"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                    <color key="textColor" white="0.63418560606060592" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="textColor" red="0.63418561220169067" green="0.63418561220169067" blue="0.63418561220169067" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="vQl-IA-A14" secondAttribute="trailing" constant="10" id="0XC-fB-v9s"/>
                                 <constraint firstItem="ymU-X3-A4W" firstAttribute="trailing" secondItem="UMm-O6-rLy" secondAttribute="trailing" id="0i5-gg-AeQ"/>
@@ -144,7 +149,7 @@
                             </variation>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="3js-x8-lyv">
-                            <rect key="frame" x="0.0" y="602" width="320" height="44"/>
+                            <rect key="frame" x="0.0" y="538" width="320" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vxa-dH-1Bp">
@@ -153,11 +158,11 @@
                                         <constraint firstAttribute="height" constant="21" id="360-2r-hU0"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                    <color key="textColor" white="0.84999999999999998" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="textColor" red="0.85000002384185791" green="0.85000002384185791" blue="0.85000002384185791" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
-                            <color key="backgroundColor" white="0.96999999999999997" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" red="0.97000002861022949" green="0.97000002861022949" blue="0.97000002861022949" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="centerY" secondItem="Vxa-dH-1Bp" secondAttribute="centerY" constant="0.5" id="003-YP-DU2"/>
                                 <constraint firstItem="Vxa-dH-1Bp" firstAttribute="leading" secondItem="3js-x8-lyv" secondAttribute="leading" constant="16" id="EEo-F6-t5q"/>
@@ -166,10 +171,10 @@
                         </view>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="APCTextFieldTableViewCell" rowHeight="65" id="2E2-Fx-NWf" customClass="APCTextFieldTableViewCell">
-                                <rect key="frame" x="0.0" y="245" width="320" height="65"/>
+                                <rect key="frame" x="0.0" y="181" width="320" height="65"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2E2-Fx-NWf" id="olN-SL-drS">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dxl-CJ-CsB">
@@ -205,10 +210,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="APCDefaultTableViewCell" id="wbA-db-hz4" customClass="APCDefaultTableViewCell">
-                                <rect key="frame" x="0.0" y="310" width="320" height="64"/>
+                                <rect key="frame" x="0.0" y="246" width="320" height="64"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="wbA-db-hz4" id="L11-hb-f8A">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="63.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="63"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="add weight (lbs.)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="bZk-oc-H5i">
@@ -243,10 +248,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="APCPickerTableViewCell" rowHeight="164" id="iny-eu-p9q" customClass="APCPickerTableViewCell">
-                                <rect key="frame" x="0.0" y="374" width="320" height="164"/>
+                                <rect key="frame" x="0.0" y="310" width="320" height="164"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="iny-eu-p9q" id="47Z-m8-fc7">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="163.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="163"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="VOQ-Xa-Vg4">
@@ -279,10 +284,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="APCSwitchTableViewCell" id="XjR-k1-ssh" customClass="APCSwitchTableViewCell">
-                                <rect key="frame" x="0.0" y="538" width="320" height="64"/>
+                                <rect key="frame" x="0.0" y="474" width="320" height="64"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="XjR-k1-ssh" id="R7Y-lH-nIr">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="63.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="63"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AuT-nK-R7J">
@@ -330,7 +335,6 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="applicationNameLabel" destination="H3m-U4-zNB" id="6Xe-4F-enL"/>
                         <outlet property="editLabel" destination="vQl-IA-A14" id="poa-Ao-Vzy"/>
@@ -356,18 +360,18 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="65" sectionHeaderHeight="40" sectionFooterHeight="22" id="v8X-VI-tRW">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="dKz-vu-nyK">
-                            <rect key="frame" x="0.0" y="528" width="320" height="44"/>
+                            <rect key="frame" x="0.0" y="464" width="320" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" white="0.96999999999999997" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" red="0.97000002861022949" green="0.97000002861022949" blue="0.97000002861022949" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="APCPickerTableViewCell" rowHeight="164" id="MmV-I6-Vyk" customClass="APCPickerTableViewCell">
-                                <rect key="frame" x="0.0" y="104" width="320" height="164"/>
+                                <rect key="frame" x="0.0" y="40" width="320" height="164"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MmV-I6-Vyk" id="vrD-Bs-alP">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="163.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="163"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="AFT-k9-Yr8">
@@ -400,10 +404,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="APCSwitchTableViewCell" id="LHr-YE-LOZ" customClass="APCSwitchTableViewCell">
-                                <rect key="frame" x="0.0" y="268" width="320" height="65"/>
+                                <rect key="frame" x="0.0" y="204" width="320" height="65"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LHr-YE-LOZ" id="JEF-8b-1Vb">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nCp-5d-3Br">
@@ -412,7 +416,7 @@
                                                 <constraint firstAttribute="height" constant="21" id="xjG-Z5-GYl"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rKj-i3-4yS">
@@ -440,51 +444,51 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="APCBasicTableViewCell" textLabel="XHH-KD-Naj" style="IBUITableViewCellStyleDefault" id="h74-ts-n5O">
-                                <rect key="frame" x="0.0" y="333" width="320" height="65"/>
+                                <rect key="frame" x="0.0" y="269" width="320" height="65"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="h74-ts-n5O" id="fYu-qb-FfB">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XHH-KD-Naj">
-                                            <rect key="frame" x="15" y="0.0" width="290" height="64.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="290" height="64"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="APCRightDetailTableViewCell" textLabel="FQR-cG-rBp" detailTextLabel="3LN-Wg-wfS" style="IBUITableViewCellStyleValue1" id="wf3-ov-7IJ">
-                                <rect key="frame" x="0.0" y="398" width="320" height="65"/>
+                                <rect key="frame" x="0.0" y="334" width="320" height="65"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="wf3-ov-7IJ" id="2lo-ez-gMg">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="64.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="64"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FQR-cG-rBp">
-                                            <rect key="frame" x="15" y="23" width="31.5" height="19.5"/>
+                                            <rect key="frame" x="15" y="22" width="32" height="20"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3LN-Wg-wfS">
-                                            <rect key="frame" x="243.5" y="23" width="41.5" height="19.5"/>
+                                            <rect key="frame" x="243" y="22" width="42" height="20"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="APCDefaultTableViewCell" id="yu9-BS-MED" customClass="APCDefaultTableViewCell">
-                                <rect key="frame" x="0.0" y="463" width="320" height="65"/>
+                                <rect key="frame" x="0.0" y="399" width="320" height="65"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="yu9-BS-MED" id="Pop-Ej-Tbo">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WO7-sk-hXC">
@@ -494,7 +498,7 @@
                                                 <constraint firstAttribute="height" constant="21" id="xQq-8H-gGT"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="gyM-2c-l4q">
@@ -503,7 +507,7 @@
                                                 <constraint firstAttribute="height" constant="21" id="ZMi-OH-M6h"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -530,7 +534,6 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Activity Reminders" id="TLB-6i-pxR"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rHv-kD-Bbp" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -550,21 +553,21 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="65" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="Ju2-WN-ZuL">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="503"/>
-                                <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="TzR-95-2rt">
-                                    <rect key="frame" x="0.0" y="64" width="320" height="70"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please help us make our study better by explaining the reasons for your withdrawal." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w0A-pl-Wzd">
                                             <rect key="frame" x="17" y="4" width="289" height="36"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <color key="textColor" white="0.59879032258064513" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="textColor" red="0.59879034757614136" green="0.59879034757614136" blue="0.59879034757614136" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select all that apply." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cpP-7K-8Bb">
                                             <rect key="frame" x="17" y="44" width="289" height="18"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <color key="textColor" white="0.60212953629032262" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="textColor" red="0.60212951898574829" green="0.60212951898574829" blue="0.60212951898574829" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -580,16 +583,16 @@
                                     </constraints>
                                 </view>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="f1p-oh-OlA">
-                                    <rect key="frame" x="0.0" y="221" width="320" height="44"/>
+                                    <rect key="frame" x="0.0" y="157" width="320" height="44"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="APCCheckTableViewCell" rowHeight="65" id="h1a-Ry-S0U" customClass="APCCheckTableViewCell">
-                                        <rect key="frame" x="0.0" y="156" width="320" height="65"/>
+                                        <rect key="frame" x="0.0" y="92" width="320" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="h1a-Ry-S0U" id="2FI-8Y-nw5">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This study was taking up too much of my time." lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hCE-XZ-mEv">
@@ -598,12 +601,12 @@
                                                         <constraint firstAttribute="height" constant="44" id="rgD-r3-csD"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yye-Jc-mNT" customClass="APCConfirmationView">
                                                     <rect key="frame" x="275" y="17" width="29" height="29"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="29" id="0iP-xr-YFg"/>
                                                         <constraint firstAttribute="width" constant="29" id="IMw-5W-Oek"/>
@@ -633,14 +636,14 @@
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                 <state key="normal" title="Withdraw">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="submit:" destination="EMw-TM-xWF" eventType="touchUpInside" id="Wzg-c4-9Bb"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Ju2-WN-ZuL" firstAttribute="leading" secondItem="G2X-UV-CbK" secondAttribute="leading" id="EOT-xe-WSw"/>
                             <constraint firstItem="NvP-cA-e45" firstAttribute="top" secondItem="o0S-br-ebJ" secondAttribute="bottom" constant="13" id="KaZ-Ns-ZFl"/>
@@ -659,7 +662,6 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="headerLabel" destination="w0A-pl-Wzd" id="tpz-EF-MTE"/>
                         <outlet property="selectAllLabel" destination="cpP-7K-8Bb" id="7Il-ft-nPE"/>
@@ -689,11 +691,11 @@
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Describe why you are withdrawing in your own words." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="17V-e9-oMl">
                                         <rect key="frame" x="7" y="4" width="306" height="40"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="17V-e9-oMl" secondAttribute="trailing" constant="7" id="BKb-yG-POU"/>
                                     <constraint firstItem="17V-e9-oMl" firstAttribute="leading" secondItem="C4N-xE-nAQ" secondAttribute="leading" constant="7" id="Uuw-JO-wV9"/>
@@ -704,7 +706,7 @@
                             </view>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GaU-t1-TAd">
                                 <rect key="frame" x="0.0" y="112" width="320" height="374"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <connections>
@@ -718,15 +720,15 @@
                                     <constraint firstAttribute="width" constant="146" id="cRa-eH-eQv"/>
                                 </constraints>
                                 <state key="normal" title="Done">
-                                    <color key="titleColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="done:" destination="f5S-nA-hza" eventType="touchUpInside" id="BGZ-XK-VQs"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="C4N-xE-nAQ" firstAttribute="leading" secondItem="BGX-h4-ttl" secondAttribute="leadingMargin" constant="-16" id="3bk-kT-pQO"/>
                             <constraint firstAttribute="trailing" secondItem="roj-Aw-erm" secondAttribute="trailing" constant="87" id="4S3-zw-w14"/>
@@ -748,7 +750,6 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="doneButton" destination="roj-Aw-erm" id="Eo3-w2-zLp"/>
                         <outlet property="doneButtonBottomLayoutConstraint" destination="kyR-Gu-FeP" id="9uP-GN-AyO"/>
@@ -786,11 +787,11 @@
                                     <constraint firstAttribute="height" constant="91" id="cMK-Eb-jfr"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="centerX" secondItem="J3v-f8-Ygf" secondAttribute="centerX" id="63k-Nw-hQS"/>
                             <constraint firstItem="BcC-vd-hvB" firstAttribute="top" secondItem="J3v-f8-Ygf" secondAttribute="bottom" constant="8" id="VbI-ak-gYJ"/>
@@ -800,7 +801,6 @@
                     </view>
                     <navigationItem key="navigationItem" title="Withdrawal Complete" id="rLJ-rs-VCY"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="logoImageVIew" destination="J3v-f8-Ygf" id="nPT-xn-WRV"/>
                         <outlet property="messageLabel" destination="BcC-vd-hvB" id="HPF-7h-LUh"/>
@@ -828,7 +828,7 @@
                                     <constraint firstAttribute="height" constant="66" id="jvW-T1-9s9"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="34"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Research Institute will receive your study data form your participation in this study." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="cy9-c7-W6M">
@@ -837,30 +837,30 @@
                                     <constraint firstAttribute="height" constant="173" id="YDz-NG-nsg"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="65" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="QgD-ne-FxW">
                                 <rect key="frame" x="0.0" y="338" width="320" height="230"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="WfS-fw-zX9">
                                     <rect key="frame" x="0.0" y="87" width="320" height="1"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="SharingOptionsTableViewCell" textLabel="M3v-5K-FBg" rowHeight="65" style="IBUITableViewCellStyleDefault" id="rcy-1s-nw5">
                                         <rect key="frame" x="0.0" y="22" width="320" height="65"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rcy-1s-nw5" id="HTC-Es-pqS">
-                                            <rect key="frame" x="0.0" y="0.0" width="281" height="64.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="281" height="64"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="M3v-5K-FBg">
-                                                    <rect key="frame" x="15" y="0.0" width="266" height="64.5"/>
+                                                    <rect key="frame" x="15" y="0.0" width="266" height="64"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -873,7 +873,7 @@
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="QgD-ne-FxW" secondAttribute="trailing" id="2D8-wQ-F44"/>
                             <constraint firstItem="cy9-c7-W6M" firstAttribute="leading" secondItem="1KR-oQ-YWJ" secondAttribute="leadingMargin" id="3Dh-VA-MCa"/>
@@ -895,7 +895,6 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="messageLabel" destination="cy9-c7-W6M" id="emo-eb-uqg"/>
                         <outlet property="tableView" destination="QgD-ne-FxW" id="1pj-I6-O4s"/>
@@ -913,10 +912,10 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="2Gq-N7-6Hg">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="LicenseInfoCell" textLabel="CIm-PK-XD0" detailTextLabel="gJx-nK-Mzv" rowHeight="84" style="IBUITableViewCellStyleSubtitle" id="Mbe-Ag-AkN">
-                                <rect key="frame" x="0.0" y="113.5" width="320" height="84"/>
+                                <rect key="frame" x="0.0" y="56" width="320" height="84"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Mbe-Ag-AkN" id="x9G-uo-g9m">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="84"/>
@@ -926,14 +925,14 @@
                                             <rect key="frame" x="15" y="22" width="37" height="23"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gJx-nK-Mzv">
-                                            <rect key="frame" x="15" y="45" width="39.5" height="18"/>
+                                            <rect key="frame" x="15" y="45" width="40" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -947,7 +946,6 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="License Information" id="cB3-5h-qSC"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ags-g9-0aZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -971,19 +969,19 @@
                                     <constraint firstAttribute="height" constant="28" id="EHi-GJ-OJb"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TO4-cv-km7" customClass="APCPasscodeView">
                                 <rect key="frame" x="68" y="177" width="184" height="64"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="64" id="Wlx-0e-cXJ"/>
                                     <constraint firstAttribute="width" constant="184" id="tgZ-YX-QB6"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="0YA-qB-6Tx" firstAttribute="top" secondItem="lKg-tg-D7k" secondAttribute="bottom" constant="54" id="1y1-zH-eOp"/>
                             <constraint firstItem="TO4-cv-km7" firstAttribute="top" secondItem="0YA-qB-6Tx" secondAttribute="bottom" constant="31" id="FOW-b1-GlA"/>
@@ -1000,7 +998,6 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="passcodeView" destination="TO4-cv-km7" id="Juv-9W-a96"/>
                         <outlet property="textLabel" destination="0YA-qB-6Tx" id="Ftb-k5-5iA"/>
@@ -1035,7 +1032,6 @@
             <objects>
                 <navigationController storyboardIdentifier="ChangePasscodeVC" automaticallyAdjustsScrollViewInsets="NO" id="JBM-IZ-MHL" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="q7C-jG-dyQ">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -1068,8 +1064,8 @@
                                     <constraint firstAttribute="width" constant="146" id="pt9-DO-Vfj"/>
                                 </constraints>
                                 <state key="normal" title="Download Data">
-                                    <color key="titleColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.97254901959999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="downloadData:" destination="vk1-Of-g9A" eventType="touchUpInside" id="Hb2-u7-sv7"/>
@@ -1082,7 +1078,7 @@
                                     <constraint firstAttribute="width" constant="38" id="Q3A-fR-DfQ"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="End" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GvA-QA-AGt" userLabel="EndLabel">
@@ -1092,7 +1088,7 @@
                                     <constraint firstAttribute="height" constant="21" id="Gqn-ib-XZ1"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hBd-OE-m9S" userLabel="StartDate">
@@ -1112,7 +1108,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="centerY" secondItem="lO2-pM-TX8" secondAttribute="centerY" constant="30" id="0CW-k8-9p8"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hBd-OE-m9S" secondAttribute="trailing" constant="16" id="10a-6d-woc"/>
@@ -1130,7 +1126,6 @@
                     </view>
                     <navigationItem key="navigationItem" title="Download Data" id="aoG-ly-D0T" userLabel="Download Data"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
                     <connections>
                         <outlet property="downloadButton" destination="eUN-2a-GKO" id="Ixf-yz-Nwm"/>
                         <outlet property="endTextField" destination="lO2-pM-TX8" id="Rid-9I-FWU"/>
@@ -1140,6 +1135,111 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HP0-7C-aBY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1794" y="1835"/>
+        </scene>
+        <!--Referral Code-->
+        <scene sceneID="vBa-WY-ce3">
+            <objects>
+                <viewController storyboardIdentifier="APCAddReferralCodeViewController" title="Referral Code" id="Acj-Zo-NdC" customClass="APCAddReferralCodeViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="uB8-mG-0j9"/>
+                        <viewControllerLayoutGuide type="bottom" id="5Ae-Qd-u15"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="M0p-UP-s11">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Optional" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bcb-Pt-ihJ" customClass="APCFormTextField">
+                                <rect key="frame" x="132" y="227" width="172" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="sag-e9-U07"/>
+                                </constraints>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet"/>
+                                <connections>
+                                    <outlet property="delegate" destination="Acj-Zo-NdC" id="e17-5i-XeD"/>
+                                </connections>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Do you have a referral code? Please enter it below." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9WY-fT-D40">
+                                <rect key="frame" x="32" y="93" width="257" height="89"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="89" id="GUk-u1-N8O"/>
+                                    <constraint firstAttribute="width" constant="257" id="y4y-RU-5Fy"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9XQ-gO-TbU">
+                                <rect key="frame" x="0.0" y="210" width="320" height="1"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="p3t-Oh-i82"/>
+                                </constraints>
+                            </view>
+                            <view alpha="0.10000000149011612" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QFD-Ns-QhZ">
+                                <rect key="frame" x="0.0" y="270" width="320" height="1"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="Ggl-b9-z2I"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Referral code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kx4-Ul-Wa4">
+                                <rect key="frame" x="16" y="231" width="101" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="101" id="Xlt-iH-0pG"/>
+                                    <constraint firstAttribute="height" constant="21" id="qtz-v7-M1g"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Example: ref_code" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wlt-a9-GwR">
+                                <rect key="frame" x="86" y="279" width="149" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="JBV-yh-RPz"/>
+                                    <constraint firstAttribute="width" constant="149" id="hdr-lt-wQn"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="9XQ-gO-TbU" firstAttribute="top" secondItem="9WY-fT-D40" secondAttribute="bottom" constant="28" id="1X5-vn-UT1"/>
+                            <constraint firstItem="Kx4-Ul-Wa4" firstAttribute="leading" secondItem="M0p-UP-s11" secondAttribute="leadingMargin" id="FbA-cD-y7I"/>
+                            <constraint firstItem="Bcb-Pt-ihJ" firstAttribute="leading" secondItem="Kx4-Ul-Wa4" secondAttribute="trailing" constant="15" id="Fmo-oN-Utx"/>
+                            <constraint firstItem="Wlt-a9-GwR" firstAttribute="top" secondItem="QFD-Ns-QhZ" secondAttribute="bottom" constant="8" id="Kzj-tu-NAw"/>
+                            <constraint firstItem="Kx4-Ul-Wa4" firstAttribute="top" secondItem="9XQ-gO-TbU" secondAttribute="bottom" constant="20" id="WGs-ZJ-iQR"/>
+                            <constraint firstItem="QFD-Ns-QhZ" firstAttribute="leading" secondItem="M0p-UP-s11" secondAttribute="leading" id="XAv-O1-74e"/>
+                            <constraint firstItem="Wlt-a9-GwR" firstAttribute="centerX" secondItem="M0p-UP-s11" secondAttribute="centerX" id="ZDT-Ax-iG8"/>
+                            <constraint firstItem="QFD-Ns-QhZ" firstAttribute="top" secondItem="Bcb-Pt-ihJ" secondAttribute="bottom" constant="13" id="Zd1-CD-JFQ"/>
+                            <constraint firstAttribute="trailing" secondItem="QFD-Ns-QhZ" secondAttribute="trailing" id="ZeS-VK-BKm"/>
+                            <constraint firstItem="Bcb-Pt-ihJ" firstAttribute="top" secondItem="9XQ-gO-TbU" secondAttribute="bottom" constant="16" id="eL8-WH-DHH"/>
+                            <constraint firstItem="9WY-fT-D40" firstAttribute="top" secondItem="uB8-mG-0j9" secondAttribute="bottom" constant="29" id="lX1-ri-aDZ"/>
+                            <constraint firstItem="9XQ-gO-TbU" firstAttribute="leading" secondItem="M0p-UP-s11" secondAttribute="leading" id="ldo-22-ZUC"/>
+                            <constraint firstAttribute="trailing" secondItem="9XQ-gO-TbU" secondAttribute="trailing" id="sNk-Ju-XwW"/>
+                            <constraint firstItem="Bcb-Pt-ihJ" firstAttribute="trailing" secondItem="M0p-UP-s11" secondAttribute="trailingMargin" id="vGv-5x-tyN"/>
+                            <constraint firstItem="9WY-fT-D40" firstAttribute="centerX" secondItem="M0p-UP-s11" secondAttribute="centerX" id="vKI-Tu-qR1"/>
+                        </constraints>
+                    </view>
+                    <toolbarItems/>
+                    <navigationItem key="navigationItem" title="Referral Code" id="YrF-Hl-8IH">
+                        <barButtonItem key="rightBarButtonItem" title="Next" id="FgN-cv-Oyk">
+                            <connections>
+                                <action selector="nextHit:" destination="Acj-Zo-NdC" id="swz-cI-V2d"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="textField" destination="Bcb-Pt-ihJ" id="SCz-GJ-ubM"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Etl-NE-u4L" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1382" y="1167"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
Add referral code entry as step to onboarding process and as option on APCProfileVC for user to add code later:
- Modify onboarding step model to include the referral code step
- Add APCReferralCodeViewController class for use during onboarding
- Add APCAddReferralCodeViewController subclass for use from Profile VC
- Add APCReferralCodeTextField custom class to validate text entry and provide some extra properties needed during input
- Modify APCUser to use new signUpStudyParticipant call so we can pass the referral code (using externalId property)
- Modify APCSpinnerViewController to show green checkmark before dismissing
- Modify APCProfileVC to include "Enter referral code" option in it's model
